### PR TITLE
Rake tasks: corrected, described, and DRYed up

### DIFF
--- a/lib/queue_classic/tasks.rb
+++ b/lib/queue_classic/tasks.rb
@@ -14,7 +14,7 @@ namespace :qc do
 
   desc 'Returns the number of jobs in the (default or QUEUE) queue'
   task :jobs => :environment do
-    puts QC.length
+    puts QC::Queue.new(ENV['QUEUE']).length
   end
 
   desc 'Ensure the database has the necessary functions for QC'


### PR DESCRIPTION
I corrected qc:jobs (queue_length -> length).
Added a few descriptions.
Alaised the duplicate task.
