### PR TITLE
Add `transaction` helper method for batch queueing.

### DIFF
--- a/lib/queue_classic/database.rb
+++ b/lib/queue_classic/database.rb
@@ -54,6 +54,21 @@ module QC
       log("done waiting for notify")
     end
 
+    def transaction
+      begin
+        execute 'BEGIN'
+        yield
+        execute 'COMMIT'
+      rescue Exception
+        execute 'ROLLBACK'
+        raise
+      end
+    end
+
+    def transaction_idle?
+      connection.transaction_status == PGconn::PQTRANS_IDLE
+    end
+
     def execute(sql, *params)
       log("executing #{sql.inspect}, #{params.inspect}")
       begin


### PR DESCRIPTION
Add a `transaction` method to the Database class which allows batch queueing of jobs in a single transaction. This is largely based on the `qc_txn` example in the [Tips & Tricks](https://github.com/ryandotsmith/queue_classic/blob/master/doc/tipsandtricks.md) documentation.
