### PR TITLE
Queue class enqueues a job

### DIFF
--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -2,9 +2,9 @@ module QC
   module AbstractQueue
 
     def enqueue(job,*params)
-      if job.respond_to?(:details) and job.respond_to?(:params)
-        job = job.signature
+      if job.respond_to?(:signature) and job.respond_to?(:params)
         params = *job.params
+        job = job.signature
       end
       array << {"job" => job, "params" => params}
     end

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -1,4 +1,5 @@
 require File.expand_path("../helper.rb", __FILE__)
+require 'ostruct'
 
 context "Queue" do
 
@@ -56,6 +57,14 @@ context "Queue" do
     QC::Queue.enqueue "Klass.method"
     QC::Queue.dequeue
     assert_equal 1, @database.execute("SELECT count(*) from pg_stat_activity")[0]["count"].to_i
+  end
+
+  test "Queue class enqueues a job" do
+    job = OpenStruct.new :signature => 'Klass.method', :params => ['param']
+    QC::Queue.enqueue(job)
+    dequeued_job = QC::Queue.dequeue
+    assert_equal "Klass.method", dequeued_job.signature
+    assert_equal 'param', dequeued_job.params
   end
 
 end


### PR DESCRIPTION
I noticed there were no tests for using `Queue#enqueue` to re-enqueue a job until I tried it. Here's the error:

``` ruby
NoMethodError: undefined method `params' for "Klass.method":String
```

As you can see, simply flipping the assignment statements was all it took.

Also, the clause checks if `job` responds to `details` and then turns around and uses `signature`. I updated the clause to check for the methods used to reassign `job` and `params`.
