### PR TITLE
Add Queue test for defaut table name

### DIFF
--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -9,7 +9,8 @@ context "Queue" do
   end
 
   test "Queue class has a default table name" do
-    QC::Queue.enqueue("Klass.method")
+    default_table_name = QC::Database.new.table_name
+    assert_equal default_table_name, QC::Queue.database.table_name
   end
 
   test "Queue class responds to dequeue" do


### PR DESCRIPTION
Add a missing test to ensure the database table name used by `Queue.database` is the default as set in `Database#initialize`.
