### PR TITLE
promiscuous json gem 

### DIFF
--- a/queue_classic.gemspec
+++ b/queue_classic.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   s.add_dependency 'pg', "~> 0.11.0"
-  s.add_dependency 'json', "~> 1.6.1"
+  s.add_dependency 'json'
 end


### PR DESCRIPTION
This may be contentious, but the -> 1.6.1 json dependency conflicts with other gems we have in our Gemfile.

If not this, consider >= 1.5.whatnot.

This obviously means that if a newer json gem is releases that breaks their API (or is buggy as hell) there could be problems, but IMO it's up upstream to lock(via a Gemfile/gemspec.
