### PR TITLE
fix typo in rake task name

### DIFF
--- a/lib/queue_classic/tasks.rb
+++ b/lib/queue_classic/tasks.rb
@@ -32,7 +32,7 @@ namespace :qc do
   end
 
   desc "Remove queue_classic functions from database."
-  task :load_functions => :environment do
+  task :drop_functions => :environment do
     QC::Queries.drop_functions
   end
 end


### PR DESCRIPTION
qc:load_functions task was defined twice. Renamed the second to qc:drop_tasks. Sorry about the lack of tests...I haven't used minitest before but it looks like the built in mocking won't allow me to set an expectation on an existing object, which would probably be the easiest way to introduce some specs for the rake tasks themselves. I'll look into it more this week.
