### PR TITLE
Better argument structure for QC::Worker.new

### DIFF
--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -1,7 +1,20 @@
 module QC
   class Worker
 
-    def initialize(q_name, top_bound, fork_worker, listening_worker, max_attempts)
+    def initialize(*args)
+      if args.length == 5
+        q_name, top_bound, fork_worker, listening_worker, max_attempts = *args
+      elsif args.length <= 1
+        opts = args.first || {}
+        q_name           = opts[:q_name]           || QC::QUEUE
+        top_bound        = opts[:top_bound]        || QC::TOP_BOUND
+        fork_worker      = opts[:fork_worker]      || QC::FORK_WORKER
+        listening_worker = opts[:listening_worker] || QC::LISTENING_WORKER
+        max_attempts     = opts[:max_attempts]     || QC::MAX_LOCK_ATTEMPTS
+      else
+        raise ArgumentError, 'wrong number of arguments (expected no args, an options hash, or 5 separate args)'
+      end
+      
       log("worker initialized")
       @running = true
 


### PR DESCRIPTION
The docs say that I should be able to just do QC::Worker.new.start to fire up a consumer, but that fails b/c Worker.new requires 5 args.

Having the 5 args all in order with no defaults didn't seem very maintainable, so here's a patch to make it accept an options hash, e.g.:

```
QC::Worker.new(q_name: 'thingers', top_bound: 3, fork_worker: true, listening_worker: true, max_attempts: 5)
```

…or to use some defaults:

```
QC::Worker.new(q_name: 'thingers', listening_worker: true)
```

…or to use _all_ defaults:

```
QC::Worker.new
```

It also still works with the original 5-argument scheme, for backwards compatibility.

What do you think? I'm new to the code, so I may be missing something. Feel free to reject the pull request if this doesn't actually make sense.
