### PR TITLE
Lazy evaluate database URL

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -18,11 +18,6 @@ module QC
   SqlFunctions = File.join(QC::Root, "/sql/ddl.sql")
   DropSqlFunctions = File.join(QC::Root, "/sql/drop_ddl.sql")
 
-  DB_URL =
-    ENV["QC_DATABASE_URL"] ||
-    ENV["DATABASE_URL"]    ||
-    raise(ArgumentError, "missing QC_DATABASE_URL or DATABASE_URL")
-
   # You can use the APP_NAME to query for
   # postgres related process information in the
   # pg_stat_activity table. Don't set this unless

--- a/lib/queue_classic/conn.rb
+++ b/lib/queue_classic/conn.rb
@@ -84,7 +84,11 @@ module QC
     end
 
     def db_url
-      URI.parse(DB_URL)
+      return @db_url if @db_url
+      url = ENV["QC_DATABASE_URL"] ||
+            ENV["DATABASE_URL"]    ||
+            raise(ArgumentError, "missing QC_DATABASE_URL or DATABASE_URL")
+      @db_url = URI.parse(url)
     end
 
     def log(msg)


### PR DESCRIPTION
Stops DB_URL constant being assigned at load time and defers until first use.
