### PR TITLE
qc:drop_function does not drop functions

### DIFF
--- a/lib/queue_classic/queries.rb
+++ b/lib/queue_classic/queries.rb
@@ -44,6 +44,7 @@ module QC
         Conn.execute(file.read)
       end
       file.close
+      Conn.disconnect
     end
 
     def drop_functions
@@ -52,6 +53,7 @@ module QC
         Conn.execute(file.read)
       end
       file.close
+      Conn.disconnect
     end
 
   end

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -58,9 +58,9 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION lock_head(tname varchar)
+CREATE OR REPLACE FUNCTION lock_head(q_name varchar)
 RETURNS SETOF queue_classic_jobs AS $$
 BEGIN
-  RETURN QUERY EXECUTE 'SELECT * FROM lock_head($1,10)' USING tname;
+  RETURN QUERY EXECUTE 'SELECT * FROM lock_head($1,10)' USING q_name;
 END;
 $$ LANGUAGE plpgsql;

--- a/sql/drop_ddl.sql
+++ b/sql/drop_ddl.sql
@@ -1,2 +1,2 @@
-DROP FUNCTION IF EXISTS lock_head(tname varchar);
-DROP FUNCTION IF EXISTS lock_head(tname name, top_boundary integer);
+DROP FUNCTION IF EXISTS lock_head(q_name varchar);
+DROP FUNCTION IF EXISTS lock_head(q_name varchar, top_boundary integer);


### PR DESCRIPTION
This fixes that and it also disconnects from the database after loading/dropping the functions in order to clean up any connections that are left in case we need to, say, drop the database after dropping functions.
