### PR TITLE
fix drop_ddl and add load and unload queries

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -17,6 +17,7 @@ module QC
   Root = File.expand_path("..", File.dirname(__FILE__))
   SqlFunctions = File.join(QC::Root, "/sql/ddl.sql")
   DropSqlFunctions = File.join(QC::Root, "/sql/drop_ddl.sql")
+  CreateWorkerTable = File.join(QC::Root, "/sql/create_worker_table.sql")
 
   # You can use the APP_NAME to query for
   # postgres related process information in the

--- a/lib/queue_classic/queries.rb
+++ b/lib/queue_classic/queries.rb
@@ -2,6 +2,29 @@ module QC
   module Queries
     extend self
 
+    def load_qc
+      self.create_worker_table
+      self.load_functions
+    end
+
+    def unload_qc
+      self.drop_functions 
+      self.drop_worker_table
+    end
+
+    def create_worker_table
+      Conn.transaction do
+        Conn.execute(File.read(CreateWorkerTable))
+      end
+    end
+
+    def drop_worker_table
+      s = 'DROP TABLE IF EXISTS queue_classic_jobs'
+      Conn.transaction do
+        Conn.execute(s)
+      end
+    end
+
     def insert(q_name, method, args, chan=nil)
       QC.log_yield(:action => "insert_job") do
         s = "INSERT INTO #{TABLE_NAME} (q_name, method, args) VALUES ($1, $2, $3)"
@@ -39,20 +62,15 @@ module QC
     end
 
     def load_functions
-      file = File.open(SqlFunctions)
       Conn.transaction do
-        Conn.execute(file.read)
+        Conn.execute(File.read(SqlFunctions))
       end
-      file.close
     end
 
     def drop_functions
-      file = File.open(DropSqlFunctions)
       Conn.transaction do
-        Conn.execute(file.read)
+        Conn.execute(File.read(DropSqlFunctions))
       end
-      file.close
     end
-
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -55,11 +55,10 @@ database migration.
 ### Quick Start
 
 ```bash
-$ createdb queue_classic_test
-$ psql queue_classic_test -c "CREATE TABLE queue_classic_jobs (id serial, q_name varchar(255), method varchar(255), args text, locked_at timestamp);"
-$ export QC_DATABASE_URL="postgres://username:password@localhost/queue_classic_test"
 $ gem install queue_classic
-$ ruby -r queue_classic -e "QC::Queries.load_functions"
+$ createdb queue_classic_test
+$ export QC_DATABASE_URL="postgres://username:password@localhost/queue_classic_test"
+$ ruby -r queue_classic -e "QC::Queries.load_qc"
 $ ruby -r queue_classic -e "QC.enqueue('Kernel.puts', 'hello world')"
 $ ruby -r queue_classic -e "QC::Worker.new.start"
 ```
@@ -90,7 +89,25 @@ ENV["DATABASE_URL"] = "postgres://username:password@localhost/database_name"
 **db/migrations/add_queue_classic.rb**
 
 ```ruby
-class CreateJobsTable < ActiveRecord::Migration
+require 'queue_classic'
+
+class AddQueueClassic < ActiveRecord::Migration
+
+  def self.up
+    QC::Queries.load_qc
+  end
+
+  def self.down
+    QC::Queries.unload_qc
+  end
+
+end
+```
+
+The old way:
+
+```ruby
+class AddQueueClassic < ActiveRecord::Migration
 
   def self.up
     create_table :queue_classic_jobs do |t|
@@ -116,6 +133,22 @@ end
 ### Sequel Setup
 
 **db/migrations/1_add_queue_classic.rb**
+
+```ruby
+require 'queue_classic'
+
+Sequel.migration do
+  up do
+    QC::Queries.load_qc
+  end
+
+  down do
+    QC::Queries.unload_qc
+  end
+end
+```
+
+The old way:
 
 ```ruby
 Sequel.migration do

--- a/sql/create_worker_table.sql
+++ b/sql/create_worker_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE queue_classic_jobs (
+  id serial, 
+  q_name varchar(255), 
+  method varchar(255), 
+  args text, 
+  locked_at timestamp
+);

--- a/sql/drop_ddl.sql
+++ b/sql/drop_ddl.sql
@@ -1,2 +1,3 @@
 DROP FUNCTION IF EXISTS lock_head(tname varchar);
 DROP FUNCTION IF EXISTS lock_head(tname name, top_boundary integer);
+DROP FUNCTION IF EXISTS lock_head(q_name varchar, top_boundary integer)


### PR DESCRIPTION
This PR implements the following:

adds the drop function syntax for the new style of lock_head
adds a create_qc_worker_table and drop_qc_worker_table functionality to Queries module
wraps creating worker table and loading functions into one top-level command for load and unload
