### PR TITLE
remove drop of undefined function

### DIFF
--- a/sql/drop_ddl.sql
+++ b/sql/drop_ddl.sql
@@ -1,3 +1,2 @@
 DROP FUNCTION IF EXISTS lock_head(tname varchar);
-DROP FUNCTION IF EXISTS lock_head(tname name, top_boundary integer);
 DROP FUNCTION IF EXISTS lock_head(q_name varchar, top_boundary integer)


### PR DESCRIPTION
I could be wrong on this one, but so far as I can tell this function is never defined.  Since it has the check for it being defined, it doesn't hurt anything as is, but it is a little confusing.  Figured it wouldn't hurt to clean it up (I ended up digging around after seeing that the function wasn't found trying to figure out if I had created things incorrectly to start with or something).  Let me know if you need extra info or anything.  Thanks!
