### PR TITLE
fix delete all when passing queue name

### DIFF
--- a/lib/queue_classic/queries.rb
+++ b/lib/queue_classic/queries.rb
@@ -34,7 +34,7 @@ module QC
 
     def delete_all(q_name=nil)
       s = "DELETE FROM #{TABLE_NAME}"
-      s << "WHERE q_name = $1" if q_name
+      s << " WHERE q_name = $1" if q_name
       Conn.execute(*[s, q_name].compact)
     end
 

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -36,6 +36,18 @@ class QueueTest < QCTest
     assert_equal(0, QC.count)
   end
 
+  def test_delete_all_by_queue_name
+    p_queue = QC::Queue.new("priority_queue")
+    s_queue = QC::Queue.new("secondary_queue")
+    p_queue.enqueue("Klass.method")
+    s_queue.enqueue("Klass.method")
+    assert_equal(1, p_queue.count(p_queue.name))
+    assert_equal(1, s_queue.count(s_queue.name))
+    p_queue.delete_all(p_queue.name)
+    assert_equal(0, p_queue.count(p_queue.name))
+    assert_equal(1, s_queue.count(s_queue.name))
+  end
+
   def test_queue_instance
     queue = QC::Queue.new("queue_classic_jobs", false)
     queue.enqueue("Klass.method")


### PR DESCRIPTION
added missing space character in sql string, and a test.
