### PR TITLE
Update and fix OkJson

### DIFF
--- a/lib/queue_classic/okjson.rb
+++ b/lib/queue_classic/okjson.rb
@@ -1,4 +1,3 @@
-module QC
 # encoding: UTF-8
 #
 # Copyright 2011, 2012 Keith Rarick
@@ -28,6 +27,7 @@ require 'stringio'
 # Some parts adapted from
 # http://golang.org/src/pkg/json/decode.go and
 # http://golang.org/src/pkg/utf8/utf8.go
+module QC
 module OkJson
   extend self
 


### PR DESCRIPTION
I had the following trouble which prevented jobs from being processed:

```
~/work/stylesclub∴ script/rails c
Loading development environment (Rails 3.2.2)
1.9.3-p125 :001 > JSON.parse '["Andra Gallh\u00f6fer"]'
 => ["Andra Gallhöfer"] 
1.9.3-p125 :002 > QC::OkJson.decode '["Andra Gallh\u00f6fer"]'
 => ["Andra Gallh\xF6fer"] 
```

It turned out that "module QC" line masks "# encoding: UTF-8" line in okjson.rb. I updated OkJson module and moved the "offender" down.
