### PR TITLE
Adding priority queue feature

### DIFF
--- a/lib/queue_classic/queries.rb
+++ b/lib/queue_classic/queries.rb
@@ -2,10 +2,10 @@ module QC
   module Queries
     extend self
 
-    def insert(q_name, method, args, chan=nil)
+    def insert(q_name, method, args, chan=nil, priority=1)
       QC.log_yield(:action => "insert_job") do
-        s = "INSERT INTO #{TABLE_NAME} (q_name, method, args) VALUES ($1, $2, $3)"
-        res = Conn.execute(s, q_name, method, OkJson.encode(args))
+        s = "INSERT INTO #{TABLE_NAME} (q_name, method, args, priority) VALUES ($1, $2, $3, $4)"
+        res = Conn.execute(s, q_name, method, OkJson.encode(args), priority)
         Conn.notify(chan) if chan
       end
     end

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -8,8 +8,12 @@ module QC
       @chan = @name if notify
     end
 
+    def enqueue_with_priority(priority, method, *args)
+      Queries.insert(name, method, args, chan, priority)
+    end
+
     def enqueue(method, *args)
-      Queries.insert(name, method, args, chan)
+      Queries.insert(name, method, args, chan, 1)
     end
 
     def lock(top_bound=TOP_BOUND)

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ queue_classic features:
 * Fuzzy-FIFO support [academic paper](http://www.cs.tau.ac.il/~shanir/nir-pubs-web/Papers/Lock_Free.pdf)
 * Instrumentation via log output
 * Long term support
+* Support for job priorities
 
 ## Proven
 
@@ -148,7 +149,7 @@ consuming jobs (lock then delete).
 You certainly don't need the queue_classic rubygem to put a job in the queue.
 
 ```bash
-$ psql queue_classic_test -c "INSERT INTO queue_classic_jobs (q_name, method, args) VALUES ('default', 'Kernel.puts', '[\"hello world\"]');"
+$ psql queue_classic_test -c "INSERT INTO queue_classic_jobs (q_name, method, args, priority) VALUES ('default', 'Kernel.puts', '[\"hello world\"]', 1);"
 ```
 
 However, the rubygem will take care of converting your args to JSON and it will also dispatch
@@ -174,6 +175,9 @@ QC.enqueue("Kernel.puts", {"hello" => "world"})
 
 # This method has an array argument.
 QC.enqueue("Kernel.puts", ["hello", "world"])
+
+# Enqueue a job with priority 2 (Default is 1)
+QC.enqueue_with_priority(2, "Kernel.puts", "I go first")
 ```
 
 The basic idea is that all arguments should be easily encoded to json. OkJson

--- a/sql/create_table.sql
+++ b/sql/create_table.sql
@@ -3,7 +3,8 @@ CREATE TABLE queue_classic_jobs (
   q_name varchar(255),
   method varchar(255),
   args text,
-  locked_at timestamptz
+  locked_at timestamptz,
+  priority int DEFAULT 1
 );
 
-CREATE INDEX idx_qc_on_name_only_unlocked ON queue_classic_jobs (q_name, id) WHERE locked_at IS NULL;
+CREATE INDEX idx_qc_on_name_only_unlocked ON queue_classic_jobs (q_name, priority DESC, id) WHERE locked_at IS NULL;

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -35,7 +35,7 @@ BEGIN
         || ' WHERE locked_at IS NULL'
         || ' AND q_name = '
         || quote_literal(q_name)
-        || ' ORDER BY id ASC'
+        || ' ORDER BY priority DESC, id ASC'
         || ' LIMIT 1'
         || ' OFFSET ' || quote_literal(relative_top)
         || ' FOR UPDATE NOWAIT'

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -6,6 +6,10 @@ class QueueTest < QCTest
     QC.enqueue("Klass.method")
   end
 
+  def test_enqueue_with_priority
+    QC.enqueue_with_priority(2, "Klass.method")
+  end
+
   def test_lock
     QC.enqueue("Klass.method")
     expected = {:id=>"1", :method=>"Klass.method", :args=>[]}

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -75,6 +75,20 @@ class WorkerTest < QCTest
     assert_equal(0, worker.failed_count)
   end
 
+  def test_work_priority
+    p_queue = QC::Queue.new("priority_queue")
+    p_queue.enqueue("TestObject.one_arg", 3)
+    p_queue.enqueue_with_priority(2, "TestObject.one_arg", 2)
+    p_queue.enqueue_with_priority(3, "TestObject.one_arg", 1)
+    worker = TestWorker.new("priority_queue", 1, false, false, 1)
+    r = worker.work
+    assert_equal(1, r)
+    r = worker.work
+    assert_equal(2, r)
+    r = worker.work
+    assert_equal(3, r)
+  end
+
   def test_worker_listens_on_chan
     p_queue = QC::Queue.new("priority_queue")
     p_queue.enqueue("TestObject.two_args", "1", 2)


### PR DESCRIPTION
Hi,
I would like to share this simple priority queue implementation:

Simply use

``` Ruby
# Enqueue a job with priority 2 (Default is 1)
QC.enqueue_with_priority(2, "Kernel.puts", "I am important!")

# This will still work as expected
QC.enqueue("Kernel.puts", "I am a regular job")
```

to enqueue a job with custom priority. Test cases are included and all passing.
