### PR TITLE
Update readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -278,7 +278,7 @@ class MyWorker < QC::Worker
 
   # retry the job
   def handle_failure(job, exception)
-    @queue.enqueue(job[:method], job[:args])
+    @queue.enqueue(job[:method], *job[:args])
   end
 
   # the forked proc needs a new db connection


### PR DESCRIPTION
The link to the configuration options in `queue_classic.rb` was out of sync with the current version.

This likely foreshadows future issues with this particular link. Thoughts on extracting these few lines of configuration into `queue_classic/configuration`? I know this isn't very important but it may make the code a tiny bit easier to read with the tradeoff being an extra file and `require`.
