### PR TITLE
Add MIT License

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,0 +1,11 @@
+The MIT License (MIT)
+
+Copyright (c) 2012 Heroku, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+

--- a/queue_classic.gemspec
+++ b/queue_classic.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.summary       = "postgres backed queue"
   s.authors       = ["Ryan Smith (♠ ace hacker)"]
   s.homepage      = "http://github.com/ryandotsmith/queue_classic"
+  s.license       = "MIT"
 
   files = []
   files << "readme.md"

--- a/readme.md
+++ b/readme.md
@@ -565,3 +565,8 @@ $ createdb queue_classic_test
 $ export QC_DATABASE_URL="postgres://username:pass@localhost/queue_classic_test"
 $ rake
 ```
+
+### License
+
+queue_classic is released under the MIT License (http://www.opensource.org/licenses/mit-license.php).
+See the MIT-LICENSE file for details.


### PR DESCRIPTION
We'd like to use queue_classic on a project here at Pivotal Labs.  However, our clients require a license.  Of course, licensing is up to you, but to facilitate the process, this pull request would release queue_classic under the MIT License.  I made the copyright holder Heroku, Inc., as that's what some of your other repos have.
