### PR TITLE
db_url  get DATABASE_URL before QC_DATABASE_URL should be better

### DIFF
--- a/lib/queue_classic/conn.rb
+++ b/lib/queue_classic/conn.rb
@@ -85,8 +85,8 @@ module QC
 
     def db_url
       return @db_url if @db_url
-      url = ENV["QC_DATABASE_URL"] ||
-            ENV["DATABASE_URL"]    ||
+      url = ENV["DATABASE_URL"] ||
+            ENV["QC_DATABASE_URL"]    ||
             raise(ArgumentError, "missing QC_DATABASE_URL or DATABASE_URL")
       @db_url = URI.parse(url)
     end


### PR DESCRIPTION
I try queue_classic following the README.

And export QC_DATABASE_URL="postgres://username:password@localhost/queue_classic_test" has been run.
So, when I go to rails , I run rake db:migrate . It success but not create database on my project 's database but on quenue_classic_test.  
So I think db_url should get DATABASE_URL first but not QC_DATABASE_URL because DATABASE_URL 's scope is in rails's project only.
