### PR TITLE
upgrade to scrolls 0.2.1

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -12,9 +12,6 @@ require "queue_classic/worker"
 require "queue_classic/setup"
 
 module QC
-  # ENV["LOG_LEVEL"] is used in Scrolls
-  Scrolls::Log.start
-
   Root = File.expand_path("..", File.dirname(__FILE__))
   SqlFunctions = File.join(QC::Root, "/sql/ddl.sql")
   DropSqlFunctions = File.join(QC::Root, "/sql/drop_ddl.sql")

--- a/queue_classic.gemspec
+++ b/queue_classic.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   s.add_dependency "pg", "~> 0.14.0"
-  s.add_dependency "scrolls", "~> 0.0.8"
+  s.add_dependency "scrolls", "~> 0.2.1"
 end


### PR DESCRIPTION
Upgrade to `scrolls` version 0.2.1.  `Scrolls::Log.start` no longer needs to be called in the new version.  

Tests are passing on my end, log output looks to be the same.
