### PR TITLE
Remove unnecessary (and incorrect) $LOAD_PATH manipulation.

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -2,8 +2,6 @@ require "scrolls"
 require "pg"
 require "uri"
 
-$: << File.expand_path(__FILE__, "lib")
-
 require "queue_classic/okjson"
 require "queue_classic/conn"
 require "queue_classic/queries"


### PR DESCRIPTION
The line in question appends the queue_classic.rb file itself onto the $LOAD_PATH, which is likely not what was intended. Manipulation of the load path is unnecessary with a properly-structured library like this anyway, as the 'require' that loaded queue_classic.rb in the first place wouldn't have succeeded had the necessary directory to load 'queue_classic/okjson' and the rest not been in the path.
