### PR TITLE
Default whether to notify based on QC::LISTENING_WORKER

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -66,7 +66,7 @@ module QC
 
   def self.default_queue
     @default_queue ||= begin
-      Queue.new(QUEUE, LISTENING_WORKER)
+      Queue.new(QUEUE)
     end
   end
 

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -3,7 +3,7 @@ module QC
 
     attr_reader :name, :chan
 
-    def initialize(name, notify=false)
+    def initialize(name, notify=QC::LISTENING_WORKER)
       @name = name
       @chan = @name if notify
     end


### PR DESCRIPTION
I was surprised when I started using non-default queues and they were slow to find work even though I had `QC_LISTENING_WORKER=1` in the environment.

This change defaults notification based on `QC::LISTENING_WORKER` for all instantiated queues, not just the default.
