### PR TITLE
Add link to queue_classic_java fork.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -556,6 +556,7 @@ end
 * Ruby 1.9.2 (tests work in 1.8.7 but compatibility is not guaranteed or supported)
 * Postgres ~> 9.0
 * Rubygem: pg ~> 0.11.0
+* For JRuby, see [queue_classic_java](https://github.com/bdon/queue_classic_java)
 
 ### Running Tests
 


### PR DESCRIPTION
We've done some work to make queue_classic JRuby compatible, and would like to get this onto Rubygems. The changes are pretty involved (https://github.com/bdon/queue_classic_java/compare/b93974...148c79), so cluttering the main qc codebase seems like a bad idea.  

The best solution I can think of is to create a separate gem called queue_classic_java that's forked off of this one. Let me know if this sounds fine.
