### PR TITLE
QC.respond_to?(:enqueue) returns false

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -62,6 +62,11 @@ module QC
     default_queue.send(sym, *args, &block)
   end
 
+  # Ensure QC.respond_to?(:enqueue) equals true (ruby 1.9 only)
+  def self.respond_to_missing?(method_name, include_private = false)
+    default_queue.respond_to?(method_name)
+  end
+
   def self.default_queue
     @default_queue ||= begin
       Queue.new(QUEUE)

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -6,6 +6,10 @@ class QueueTest < QCTest
     QC.enqueue("Klass.method")
   end
 
+  def test_respond_to
+    assert_equal(true, QC.respond_to?(:enqueue))
+  end
+
   def test_lock
     QC.enqueue("Klass.method")
     expected = {:id=>"1", :method=>"Klass.method", :args=>[]}


### PR DESCRIPTION
Ruby 1.9. has a mechanism to handle this. I did a dirty implementation of it - seems to work fine.
