### PR TITLE
Updated PG to 0.14.1

### DIFF
--- a/queue_classic.gemspec
+++ b/queue_classic.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.require_paths = %w[lib]
 
-  s.add_dependency "pg", "~> 0.14.0"
+  s.add_dependency "pg", "~> 0.14.1"
   s.add_dependency "scrolls", "~> 0.2.1"
 end


### PR DESCRIPTION
Hello,

I updated the gem and ran 'rake test', with the following results:
# Running tests:

lib=queue_classic action=insert_job elapsed=53
.lib=queue_classic action=insert_job elapsed=51
lib=queue_classic error="#<PG::Error: PG::Error>"
lib=queue_classic level=error error=PG::Error message=PG::Error action=insert_job
lib=queue_classic action=insert_job elapsed=3
.lib=queue_classic action=insert_job elapsed=55
lib=queue_classic action=insert_job elapsed=4
.lib=queue_classic action=insert_job elapsed=59
lib=queue_classic action=insert_job elapsed=15
.lib=queue_classic action=insert_job elapsed=54
.lib=queue_classic action=insert_job elapsed=59
.lib=queue_classic action=insert_job elapsed=56
.lib=queue_classic action=insert_job elapsed=61
..lib=queue_classic action=insert_job elapsed=56
.lib=queue_classic action=insert_job elapsed=57
.lib=queue_classic action=insert_job elapsed=51
.lib=queue_classic action=insert_job elapsed=60
.lib=queue_classic action=insert_job elapsed=59
.lib=queue_classic action=insert_job elapsed=60
.lib=queue_classic action=insert_job elapsed=56
.lib=queue_classic action=insert_job elapsed=23
.

Finished tests in 2.116177s, 8.0334 tests/s, 15.1216 assertions/s.

17 tests, 32 assertions, 0 failures, 0 errors, 0 skips

I've run this in our test environment against Postgres 9.2, and it seems to be running pretty well.  I added this update to address some problems in my multithreaded application, which was getting tripped up by SIGSEGV errors thrown by PG 0.14.0.

Thanks for your hard work on this gem - it's worked quite well for my application.

Regards,
Jeremy
