### PR TITLE
Allow percent-encoded socket paths in ENV[{QC_,}DATABASE_URL]

### DIFF
--- a/lib/queue_classic/conn.rb
+++ b/lib/queue_classic/conn.rb
@@ -72,7 +72,7 @@ module QC
     def connect
       log(:level => :debug, :action => "establish_conn")
       conn = PGconn.connect(
-        db_url.host,
+        db_url.host.gsub(/%2F/i, '/'), # host or percent-encoded socket path
         db_url.port || 5432,
         nil, '', #opts, tty
         db_url.path.gsub("/",""), # database name

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,15 @@ queue_classic requires a database table and a PL/pgSQL function to be loaded
 into your database. You can load the table and the function by running a migration
 or using a rake task.
 
+note: if connecting to postgresql server using unix sockets instead of tcp sockets,
+use the percent-encoded path of the socket directory as the host part of `DATABASE_URL`.
+
+```ruby
+# Optional if you have this set in your shell environment or use Heroku.
+# Using socket to connect to the local postgresql listening at unix:/var/run/postgresql
+ENV["DATABASE_URL"] = "postgres://username:password@%Fvar%Frun%Fpostgresql/database_name"
+```
+
 **db/migrate/add_queue_classic.rb**
 
 ```ruby


### PR DESCRIPTION
Since PostgreSQL 9.2, percent-encoded _socket paths_ are allowed in the _host_ part of the connection string URI [source](http://www.postgresql.org/docs/9.2/interactive/libpq-connect.html).

This PR allows the following style of `PG_DATABASE_URL` or `DATABASE_URL` environment variables:

```
DATABASE_URL='postgresql://username:password@%2Fvar%2Frun%2Fpostgresql/dbname'
```

ActiveRecord already supports percent-encoded _host_, as every part of the connection URL is [URI.unescape](https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb#L71)'d.

I have manually tested using the Rails console that this style of database URL is compatible with both `queue_classic` and `ActiveRecord` using the following simple commands:

``` ruby
puts ENV['QC_DATABASE_URL']
puts QC::Conn.connection.exec('select current_timestamp').to_a.inspect
ActiveRecord::Base.establish_connection ENV['QC_DATABASE_URL']
puts ActiveRecord::Base.connection.raw_connection.exec('select current_timestamp').to_a
```

This PR solves issue #72.
