### PR TITLE
don't try to fetch more jobs after having been signaled

### DIFF
--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -103,7 +103,7 @@ module QC
       log(:level => :debug, :action => "lock_job")
       attempts = 0
       job = nil
-      until job
+      until !running? || job
         job = @queue.lock(@top_bound)
         if job.nil?
           log(:level => :debug, :action => "failed_lock", :attempts => attempts)


### PR DESCRIPTION
This helps the worker exit promptly after it's been signaled, instead of it waiting to be more forcefully shut down by the supervisor/runtime later.
