### PR TITLE
Support 64-bit precision all around

### DIFF
--- a/sql/create_table.sql
+++ b/sql/create_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE queue_classic_jobs (
-  id serial PRIMARY KEY,
+  id bigserial PRIMARY KEY,
   q_name varchar(255),
   method varchar(255),
   args text,

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -6,7 +6,7 @@
 CREATE OR REPLACE FUNCTION lock_head(q_name varchar, top_boundary integer)
 RETURNS SETOF queue_classic_jobs AS $$
 DECLARE
-  unlocked integer;
+  unlocked bigint;
   relative_top integer;
   job_count integer;
 BEGIN

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,6 +21,32 @@ class QCTest < MiniTest::Unit::TestCase
     QC::Conn.execute("SET client_min_messages TO 'warning'")
     QC::Setup.drop
     QC::Setup.create
+    QC::Conn.execute(<<EOS)
+DO $$
+-- Set initial sequence to a large number to test the entire toolchain
+-- works on integers with higher bits set.
+DECLARE
+    quoted_name text;
+    quoted_size text;
+BEGIN
+    -- Find the name of the relevant sequence.
+    --
+    -- pg_get_serial_sequence quotes identifiers as part of its
+    -- behavior.
+    SELECT name
+    INTO STRICT quoted_name
+    FROM pg_get_serial_sequence('queue_classic_jobs', 'id') AS name;
+
+    -- Don't quote, because ALTER SEQUENCE RESTART doesn't like
+    -- general literals, only unquoted numeric literals.
+    SELECT pow(2, 34)::text AS size
+    INTO STRICT quoted_size;
+
+    EXECUTE 'ALTER SEQUENCE ' || quoted_name ||
+        ' RESTART ' || quoted_size || ';';
+END;
+$$;
+EOS
     QC::Conn.disconnect
   end
 

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -8,7 +8,10 @@ class QueueTest < QCTest
 
   def test_lock
     QC.enqueue("Klass.method")
-    expected = {:id=>"1", :method=>"Klass.method", :args=>[]}
+
+    # See helper.rb for more information about the large initial id
+    # number.
+    expected = {:id=>(2**34).to_s, :method=>"Klass.method", :args=>[]}
     assert_equal(expected, QC.lock)
   end
 


### PR DESCRIPTION
32 bits of precision is not enough; it's entirely possible to run out
in a mere mortal lifetime.

Testing methodology: set the initial sequence to an integer beyond 32
bits of precision, so that every test will stress code paths involving
such larger integers, e.g. to catch anything using Fixnums on a 32-bit
build of Ruby.

It seems unlikely that a defect would arise only in cases where
numbers require limited precision and such bugs would appear right
away after starting to use queue_classic, so it seems that the loss of
testing those case is acceptable.

Signed-off-by: Daniel Farina daniel@heroku.com
