### PR TITLE
Fix error in usage example of QC::Queue.new

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ QC.enqueue("Kernel.puts", {"hello" => "world"})
 QC.enqueue("Kernel.puts", ["hello", "world"])
 
 # This method uses a non-default queue.
-p_queue = QC::Queue.new(q_name: "priority_queue")
+p_queue = QC::Queue.new("priority_queue")
 p_queue.enqueue("Kernel.puts", ["hello", "world"])
 ```
 


### PR DESCRIPTION
Maybe a wiki page would be more appropriate for this kind of info?
https://github.com/ryandotsmith/queue_classic/wiki/Using-a-named-queue
