### PR TITLE
ignore .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.ruby-version
+.bundle
 .rvmrc
 etc/
 *.gem


### PR DESCRIPTION
I am using rbenv and noticed that only the `.rvmrc` file is gitignored. Since the `.ruby-version` file can be used across version managers I suggest to ignore it as well.

Also when using bundler to manage the dependencies instead of gemsets one does usually store them in the `.bundle` directory. I also added this one to the ignore list.
