### PR TITLE
extract #perform from #work to run a job

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,13 +110,7 @@ worker = MyWorker.new(max_attempts: 10, listening_worker: true)
 loop do
 	job = worker.lock_job
 	Thread.new do
-		begin
-			Timeout::timeout(5) {worker.call(job)}
-		rescue => e
-			handle_failure(job, e)
-		ensure
-			worker.delete(job[:id])
-		end
+	  Timeout::timeout(5) { worker.process(job) }
 	end
 end
 ```


### PR DESCRIPTION
In our applications we use a custom QC worker. I need to run a job without letting the worker lock the job, so I can't call `#work`. The problem is, that you then need to duplicate the process to run a job, handle failure and remove the job.

When I also saw that exact duplication in the README I wanted to extract the code to process a job into a separate method to make the worker more reusable.

@ryandotsmith let me know what you think.
