### PR TITLE
Change `lock_head` to log and sleep before retrying

### DIFF
--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -43,7 +43,9 @@ BEGIN
       EXIT;
     EXCEPTION
       WHEN lock_not_available THEN
-        -- do nothing. loop again and hope we get a lock
+        RAISE NOTICE 'QC could not lock job';
+        EXECUTE 'SELECT pg_sleep(0.5)';
+        -- loop again and hope we get a lock
     END;
   END LOOP;
 


### PR DESCRIPTION
This should help prevent QC from consuming too much CPU if it gets
into a loop while it can't lock jobs.
