### PR TITLE
`source :rubygems` is deprecated. Use URL instead.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "http://rubygems.org"
 
 gem "rake"
 


### PR DESCRIPTION
The latest release of bundler issues a warning on Gemfiles with `source :rubygems`.
