### PR TITLE
ruby-debug19 does not work with ruby-2.0.0-p0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem "rake"
 gemspec
 
 group :test do
-  gem "ruby-debug19"
   gem "turn"
   gem "minitest"
 end


### PR DESCRIPTION
I removed the ruby-debug19 gem and all the tests pass without warnings on 2.0!
