### PR TITLE
The connection count test should restrict the test to current database.

### DIFF
--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -90,8 +90,8 @@ class WorkerTest < QCTest
     worker.work
     assert_equal(
       1,
-      QC::Conn.execute("SELECT count(*) from pg_stat_activity")["count"].to_i,
-      "Multiple connections -- Are there other connections in other terminals?"
+      QC::Conn.execute("SELECT count(*) from pg_stat_activity where datname = current_database()")["count"].to_i,
+      "Multiple connections found -- are there open connections to #{ QC::Conn.db_url } in other terminals?"
     )
   end
 


### PR DESCRIPTION
queue_classic tests fail if I have unrelated connections present to other databases. This fixes the failing test.
