### PR TITLE
Use json type for the args column if json is available.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,5 @@
-Unreleased
+Unreleased (in Git)
+- Use postgresql's json type for the args column if json type is available
 - QC::Worker#handle_failure logs the job and the error
 - QC.default_queue= to set your own default queue. (can be used
   in testing to configure a mock queue)

--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,13 @@ $ bundle exec rake qc:drop
 
 All configuration takes place in the form of environment vars. See [queue_classic.rb](https://github.com/ryandotsmith/queue_classic/blob/master/lib/queue_classic.rb#L23-62) for a list of options.
 
+## JSON
+
+If you are running PostgreSQL 9.2 or higher, queue_classic will use the [json](http://www.postgresql.org/docs/9.2/static/datatype-json.html) datatype for storing arguments. Versions 9.1 and lower will use the 'text' column. If you have installed queue_classic prior to version 2.1.4 and are running PostgreSQL >= 9.2, run the following to switch to using the json type:
+```
+alter table queue_classic_jobs alter column args type json using (args::json);
+```
+
 ## Logging
 
 By default queue_classic does not talk very much.

--- a/sql/create_table.sql
+++ b/sql/create_table.sql
@@ -1,9 +1,19 @@
+do $$ begin
+
 CREATE TABLE queue_classic_jobs (
   id bigserial PRIMARY KEY,
-  q_name varchar(255),
-  method varchar(255),
-  args text,
+  q_name text not null check (length(q_name) > 0),
+  method text not null check (length(method) > 0),
+  args   text not null,
   locked_at timestamptz
 );
+
+-- If json type is available, use it for the args column.
+perform * from pg_type where typname = 'json';
+if found then
+  alter table queue_classic_jobs alter column args type json using (args::json);
+end if;
+
+end $$ language plpgsql;
 
 CREATE INDEX idx_qc_on_name_only_unlocked ON queue_classic_jobs (q_name, id) WHERE locked_at IS NULL;


### PR DESCRIPTION
Solves #110.

If there's a `json` type, use it for the `args` column, otherwise, fallback to `text`. 
