### PR TITLE
On new job, issue NOTIFY via trigger.

### DIFF
--- a/lib/queue_classic/conn.rb
+++ b/lib/queue_classic/conn.rb
@@ -22,11 +22,6 @@ module QC
       end
     end
 
-    def notify(chan)
-      log(:at => "NOTIFY")
-      execute('NOTIFY "' + chan + '"') #quotes matter
-    end
-
     def listen(chan)
       log(:at => "LISTEN")
       execute('LISTEN "' + chan + '"') #quotes matter

--- a/lib/queue_classic/queries.rb
+++ b/lib/queue_classic/queries.rb
@@ -6,7 +6,6 @@ module QC
       QC.log_yield(:action => "insert_job") do
         s="INSERT INTO #{TABLE_NAME} (q_name, method, args) VALUES ($1, $2, $3)"
         res = Conn.execute(s, q_name, method, OkJson.encode(args))
-        Conn.notify(chan) if chan
       end
     end
 

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -1,14 +1,13 @@
 module QC
   class Queue
 
-    attr_reader :name, :chan
-    def initialize(name, notify=QC::LISTENING_WORKER)
+    attr_reader :name
+    def initialize(name)
       @name = name
-      @chan = @name if notify
     end
 
     def enqueue(method, *args)
-      Queries.insert(name, method, args, chan)
+      Queries.insert(name, method, args)
     end
 
     def lock(top_bound=TOP_BOUND)

--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -12,7 +12,7 @@ module QC
       @max_attempts     = args[:max_attempts]     ||= QC::MAX_LOCK_ATTEMPTS
 
       @running = true
-      @queue = Queue.new(@q_name, @listening_worker)
+      @queue = Queue.new(@q_name)
       log(args.merge(:at => "worker_initialized"))
     end
 
@@ -113,9 +113,9 @@ module QC
     def wait(t)
       if @listening_worker
         log(:at => "listen_wait", :wait => t)
-        Conn.listen(@queue.chan)
+        Conn.listen(@queue.name)
         Conn.wait_for_notify(t)
-        Conn.unlisten(@queue.chan)
+        Conn.unlisten(@queue.name)
         Conn.drain_notify
         log(:at => "finished_listening")
       else

--- a/sql/create_table.sql
+++ b/sql/create_table.sql
@@ -6,4 +6,14 @@ CREATE TABLE queue_classic_jobs (
   locked_at timestamptz
 );
 
+create function queue_classic_notify() returns trigger as $$ begin
+  perform pg_notify(new.q_name, '');
+  return null;
+end $$ language plpgsql;
+
+create trigger queue_classic_notify
+after insert on queue_classic_jobs
+for each row
+execute procedure queue_classic_notify();
+
 CREATE INDEX idx_qc_on_name_only_unlocked ON queue_classic_jobs (q_name, id) WHERE locked_at IS NULL;

--- a/sql/drop_ddl.sql
+++ b/sql/drop_ddl.sql
@@ -1,2 +1,3 @@
 DROP FUNCTION IF EXISTS lock_head(tname varchar);
-DROP FUNCTION IF EXISTS lock_head(q_name varchar, top_boundary integer)
+DROP FUNCTION IF EXISTS lock_head(q_name varchar, top_boundary integer);
+DROP FUNCTION IF EXISTS queue_classic_notify() cascade;

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -56,7 +56,7 @@ class QueueTest < QCTest
   end
 
   def test_queue_instance
-    queue = QC::Queue.new("queue_classic_jobs", false)
+    queue = QC::Queue.new("queue_classic_jobs")
     queue.enqueue("Klass.method")
     assert_equal(1, queue.count)
     queue.delete(queue.lock[:id])
@@ -64,7 +64,7 @@ class QueueTest < QCTest
   end
 
   def test_repair_after_error
-    queue = QC::Queue.new("queue_classic_jobs", false)
+    queue = QC::Queue.new("queue_classic_jobs")
     queue.enqueue("Klass.method")
     assert_equal(1, queue.count)
     connection = QC::Conn.connection
@@ -72,7 +72,7 @@ class QueueTest < QCTest
     def connection.exec(*args)
       raise PGError
     end
-    assert_raises(PG::Error) { queue.enqueue("Klass.other_method") }    
+    assert_raises(PG::Error) { queue.enqueue("Klass.other_method") }
     assert_equal(1, queue.count)
     queue.enqueue("Klass.other_method")
     assert_equal(2, queue.count)


### PR DESCRIPTION
This probably isn't done, as we need to tell people that they have to install
the new trigger function and the trigger if they want NOTIFY's to work
as they did before.

NOTIFY's are no longer issued by the queue_classic gem.

Solves #103.

I wonder if making queue_classic a proper pg extension would help with the upgrades..
