### PR TITLE
default `#handle_failure` logs job and error.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+Unreleased
+- QC::Worker#handle_failure logs the job and the error
+
 Version 2.1.4
 - update pg dependency to 0.15.1
 - document logging behaviour

--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -127,7 +127,7 @@ module QC
     # This method will be called when an exception
     # is raised during the execution of the job.
     def handle_failure(job,e)
-      log(:at => "handle_failure")
+      log(:at => "handle_failure", :job => job, :error => e.inspect)
     end
 
     # This method should be overriden if

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,6 +4,7 @@ $: << File.expand_path("test")
 ENV["DATABASE_URL"] ||= "postgres:///queue_classic_test"
 
 require "queue_classic"
+require "stringio"
 require "minitest/unit"
 MiniTest::Unit.autorun
 
@@ -48,6 +49,19 @@ END;
 $$;
 EOS
     QC::Conn.disconnect
+  end
+
+  def capture_debug_output
+    original_debug = ENV['DEBUG']
+    original_stdout = $stdout
+
+    ENV['DEBUG'] = "true"
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    ENV['DEBUG'] = original_debug
+    $stdout = original_stdout
   end
 
 end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -42,6 +42,15 @@ class WorkerTest < QCTest
     assert_equal(1, worker.failed_count)
   end
 
+  def test_failed_job_is_logged
+    output = capture_debug_output do
+      QC.enqueue("TestObject.not_a_method")
+      QC::Worker.new.work
+    end
+    expected_output = /lib=queue-classic at=handle_failure job={:id=>"\d+", :method=>"TestObject.not_a_method", :args=>\[\]} error=#<NoMethodError: undefined method `not_a_method' for TestObject:Module>/
+    assert_match(expected_output, output, "=== debug output ===\n #{output}")
+  end
+
   def test_work_with_no_args
     QC.enqueue("TestObject.no_args")
     worker = TestWorker.new


### PR DESCRIPTION
Closes #143.

It makes sense to log the job and error objects when an error occurs. This helps a great deal when debugging.
