### PR TITLE
Make QC.default_queue configurable

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,7 @@
 Unreleased
 - QC::Worker#handle_failure logs the job and the error
+- QC.default_queue= to set your own default queue. (can be used
+  in testing to configure a mock queue)
 
 Version 2.1.4
 - update pg dependency to 0.15.1

--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -66,6 +66,10 @@ module QC
     default_queue.respond_to?(method_name)
   end
 
+  def self.default_queue=(queue)
+    @default_queue = queue
+  end
+
   def self.default_queue
     @default_queue ||= begin
       Queue.new(QUEUE)

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -80,4 +80,24 @@ class QueueTest < QCTest
     QC::Conn.disconnect
     assert false, "Expected to QC repair after connection error"
   end
+
+  def test_custom_default_queue
+    queue_class = Class.new do
+      attr_accessor :jobs
+      def enqueue(method, *args)
+        @jobs ||= []
+        @jobs << method
+      end
+    end
+
+    queue_instance = queue_class.new
+    QC.default_queue = queue_instance
+
+    QC.enqueue("Klass.method1")
+    QC.enqueue("Klass.method2")
+
+    assert_equal ["Klass.method1", "Klass.method2"], queue_instance.jobs
+  ensure
+    QC.default_queue = nil
+  end
 end


### PR DESCRIPTION
This will help to inject custom Stub/Mock Queues when running tests with `QC`.
