### PR TITLE
Change how log_yield calculates time elapsed to match log

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@ Unreleased (in Git)
 - QC::Worker#handle_failure logs the job and the error
 - QC.default_queue= to set your own default queue. (can be used
   in testing to configure a mock queue)
+- QC.log now reports time elapsed in milliseconds.
 
 Version 2.1.4
 - update pg dependency to 0.15.1

--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -95,7 +95,7 @@ module QC
     if block_given?
       start = Time.now
       result = yield
-      data.merge(:elapsed => Time.now - start)
+      data.merge(:elapsed => Integer((Time.now - t0)*1000))
     end
     data.reduce(out=String.new) do |s, tup|
       s << [tup.first, tup.last].join("=") << " "

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -51,6 +51,24 @@ class WorkerTest < QCTest
     assert_match(expected_output, output, "=== debug output ===\n #{output}")
   end
 
+  def test_log_yield
+    output = capture_debug_output do
+      QC.log_yield(:action => "test") do
+        0 == 1
+      end
+    end
+    expected_output = /lib=queue-classic action=test elapsed=\d*/
+    assert_match(expected_output, output, "=== debug output ===\n #{output}")
+  end
+
+  def test_log
+    output = capture_debug_output do
+      QC.log(:action => "test")
+    end
+    expected_output = /lib=queue-classic action=test/
+    assert_match(expected_output, output, "=== debug output ===\n #{output}")
+  end
+
   def test_work_with_no_args
     QC.enqueue("TestObject.no_args")
     worker = TestWorker.new


### PR DESCRIPTION
This changes makes it so log and log_yield both report seconds elapsed with no rounding or casting to an integer. 
