### PR TITLE
fix `QC::Conn#connect` when url has no host.

### DIFF
--- a/lib/queue_classic/conn.rb
+++ b/lib/queue_classic/conn.rb
@@ -85,18 +85,25 @@ module QC
 
     def connect
       log(:at => "establish_conn")
-      conn = PGconn.connect(
-        db_url.host.gsub(/%2F/i, '/'), # host or percent-encoded socket path
-        db_url.port || 5432,
-        nil, '', #opts, tty
-        db_url.path.gsub("/",""), # database name
-        db_url.user,
-        db_url.password
-      )
+      conn = PGconn.connect(*normalize_db_url(db_url))
       if conn.status != PGconn::CONNECTION_OK
         log(:error => conn.error)
       end
       conn
+    end
+
+    def normalize_db_url(url)
+      host = url.host
+      host = host.gsub(/%2F/i, '/') if host
+
+      [
+       host, # host or percent-encoded socket path
+       url.port || 5432,
+       nil, '', #opts, tty
+       url.path.gsub("/",""), # database name
+       url.user,
+       url.password
+      ]
     end
 
     def db_url

--- a/test/conn_test.rb
+++ b/test/conn_test.rb
@@ -1,0 +1,22 @@
+require File.expand_path("../helper.rb", __FILE__)
+
+class ConnTest < QCTest
+
+  def test_extracts_the_segemnts_to_connect
+    database_url = "postgres://ryan:secret@localhost:1234/application_db"
+    normalized = QC::Conn.normalize_db_url(URI.parse(database_url))
+    assert_equal ["localhost",
+                  1234,
+                  nil, "",
+                  "application_db",
+                  "ryan",
+                  "secret"], normalized
+  end
+
+  def test_regression_database_url_without_host
+    database_url = "postgres:///my_db"
+    normalized = QC::Conn.normalize_db_url(URI.parse(database_url))
+    assert_equal [nil, 5432, nil, "", "my_db", nil, nil], normalized
+  end
+
+end


### PR DESCRIPTION
This is the case for the default url when running the tests:

```
    postgres:///queue_classic_test
```

This fixes the following error when running the tests without configuring the database URL:

```
NoMethodError: undefined method `gsub' for nil:NilClass
    /Users/senny/Projects/queue_classic/lib/queue_classic/conn.rb:89:in `connect'
    /Users/senny/Projects/queue_classic/lib/queue_classic/conn.rb:68:in `connection'
    /Users/senny/Projects/queue_classic/lib/queue_classic/conn.rb:13:in `block in execute'
    <internal:prelude>:10:in `synchronize'
    /Users/senny/Projects/queue_classic/lib/queue_classic/conn.rb:9:in `execute'
    /Users/senny/Projects/queue_classic/test/helper.rb:22:in `init_db'
    /Users/senny/Projects/queue_classic/test/helper.rb:14:in `setup'
```
