### PR TITLE
use json from the stdlib as MultiJson will be discontinued

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,5 @@
 Unreleased (in Git)
+- Use json from the stdlib in place of MultiJson.
 - Use postgresql's json type for the args column if json type is available
 - QC::Worker#handle_failure logs the job and the error
 - QC.default_queue= to set your own default queue. (can be used

--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -1,6 +1,6 @@
 require "pg"
 require "uri"
-require "multi_json"
+require "json"
 
 require "queue_classic/conn"
 require "queue_classic/queries"

--- a/lib/queue_classic/queries.rb
+++ b/lib/queue_classic/queries.rb
@@ -5,7 +5,7 @@ module QC
     def insert(q_name, method, args, chan=nil)
       QC.log_yield(:action => "insert_job") do
         s = "INSERT INTO #{TABLE_NAME} (q_name, method, args) VALUES ($1, $2, $3)"
-        res = Conn.execute(s, q_name, method, MultiJson.encode(args))
+        res = Conn.execute(s, q_name, method, JSON.dump(args))
         Conn.notify(chan) if chan
       end
     end
@@ -16,7 +16,7 @@ module QC
         {
           :id     => r["id"],
           :method => r["method"],
-          :args   => MultiJson.decode(r["args"])
+          :args   => JSON.parse(r["args"])
         }
       end
     end

--- a/queue_classic.gemspec
+++ b/queue_classic.gemspec
@@ -20,5 +20,4 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   s.add_dependency "pg", "~> 0.15.1"
-  s.add_dependency "multi_json", "~> 1.7.2"
 end


### PR DESCRIPTION
As described in this comment: https://github.com/intridea/multi_json/pull/113#issuecomment-17668823 `MultiJson` will be discontinued. As ruby `1.9.2` has a json library inside of stdlib we can use this one.

I did not specify the dependency in the Gemfile, people running with 1.8 could still put the `json` gem as a dependency in their Gemfile to get it working.

Closes #153
