### PR TITLE
Connection Pooling

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -46,9 +46,7 @@ module QC
   end
 
   def self.default_queue
-    @default_queue ||= begin
-      Queue.new(QUEUE)
-    end
+    @default_queue ||= Queue.new
   end
 
   def self.log_yield(data)
@@ -70,7 +68,7 @@ module QC
     if block_given?
       start = Time.now
       result = yield
-      data.merge(:elapsed => Integer((Time.now - t0)*1000))
+      data.merge(:elapsed => Integer((Time.now - start)*1000))
     end
     data.reduce(out=String.new) do |s, tup|
       s << [tup.first, tup.last].join("=") << " "

--- a/lib/queue_classic/conf.rb
+++ b/lib/queue_classic/conf.rb
@@ -1,0 +1,33 @@
+require 'uri'
+
+module QC
+  module Conf
+
+    def self.env(k); ENV[k]; end
+    def self.env!(k); env(k) || raise("Must set #{k}."); end
+
+    def self.debug?
+      !env('DEBUG').nil?
+    end
+
+    def self.db_url
+      url = env("QC_DATABASE_URL") ||
+            env("DATABASE_URL")    ||
+            raise(ArgumentError, "Must set QC_DATABASE_URL or DATABASE_URL.")
+      URI.parse(url)
+    end
+
+    def self.normalized_db_url(url=nil)
+      url ||= db_url
+      host = url.host
+      host = host.gsub(/%2F/i, '/') if host
+      [host, # host or percent-encoded socket path
+       url.port || 5432,
+       nil, '', #opts, tty
+       url.path.gsub("/",""), # database name
+       url.user,
+       url.password]
+    end
+
+  end
+end

--- a/lib/queue_classic/conn.rb
+++ b/lib/queue_classic/conn.rb
@@ -1,23 +1,38 @@
+require 'queue_classic/conf'
 require 'thread'
 require 'uri'
 require 'pg'
 
 module QC
-  module Conn
-    extend self
-    @exec_mutex = Mutex.new
+  class Conn
+
+    def self.connect
+      QC.log(:at => "establish_conn")
+      conn = PGconn.connect(*Conf.normalized_db_url)
+      if conn.status != PGconn::CONNECTION_OK
+        log(:error => conn.error)
+      end
+      if !Conf.debug?
+        conn.exec("SET client_min_messages TO 'warning'")
+      end
+      conn.exec("SET application_name = '#{QC::APP_NAME}'")
+      conn
+    end
+
+    def initialize
+      @c = self.class.connect
+    end
 
     def execute(stmt, *params)
-      @exec_mutex.synchronize do
-        log(:at => "exec_sql", :sql => stmt.inspect)
+      QC.log(:measure => "conn.exec", :sql => stmt.inspect) do
         begin
           params = nil if params.empty?
-          r = connection.exec(stmt, params)
+          r = @c.exec(stmt, params)
           result = []
           r.each {|t| result << t}
           result.length > 1 ? result : result.pop
         rescue PGError => e
-          log(:error => e.inspect)
+          QC.log(:error => e.inspect)
           disconnect
           raise
         end
@@ -31,87 +46,23 @@ module QC
       drain_notify
     end
 
-    def transaction
-      begin
-        execute("BEGIN")
-        yield
-        execute("COMMIT")
-      rescue Exception
-        execute("ROLLBACK")
-        raise
-      end
-    end
-
-    def transaction_idle?
-      connection.transaction_status == PGconn::PQTRANS_IDLE
-    end
-
-    def connection
-      @connection ||= connect
-    end
-
-    def connection=(connection)
-      unless connection.is_a? PG::Connection
-        c = connection.class
-        err = "connection must be an instance of PG::Connection, but was #{c}"
-        raise(ArgumentError, err)
-      end
-      @connection = connection
-    end
-
     def disconnect
-      begin connection.finish
-      ensure @connection = nil
+      begin @c.finish
+      ensure @c = nil
       end
-    end
-
-    def connect
-      log(:at => "establish_conn")
-      conn = PGconn.connect(*normalize_db_url(db_url))
-      if conn.status != PGconn::CONNECTION_OK
-        log(:error => conn.error)
-      end
-      conn.exec("SET application_name = '#{QC::APP_NAME}'")
-      conn
-    end
-
-    def normalize_db_url(url)
-      host = url.host
-      host = host.gsub(/%2F/i, '/') if host
-
-      [
-       host, # host or percent-encoded socket path
-       url.port || 5432,
-       nil, '', #opts, tty
-       url.path.gsub("/",""), # database name
-       url.user,
-       url.password
-      ]
-    end
-
-    def db_url
-      return @db_url if @db_url
-      url = ENV["QC_DATABASE_URL"] ||
-            ENV["DATABASE_URL"]    ||
-            raise(ArgumentError, "missing QC_DATABASE_URL or DATABASE_URL")
-      @db_url = URI.parse(url)
     end
 
     private
 
-    def log(msg)
-      QC.log(msg)
-    end
-
     def wait_for_notify(t)
       Array.new.tap do |msgs|
-        connection.wait_for_notify(t) {|event, pid, msg| msgs << msg}
+        @c.wait_for_notify(t) {|event, pid, msg| msgs << msg}
       end
     end
 
     def drain_notify
-      until connection.notifies.nil?
-        log(:at => "drain_notifications")
+      until @c.notifies.nil?
+        QC.log(:at => "drain_notifications")
       end
     end
 

--- a/lib/queue_classic/pool.rb
+++ b/lib/queue_classic/pool.rb
@@ -1,0 +1,58 @@
+require 'queue_classic/conn'
+require 'thread'
+
+module QC
+  class Pool
+
+    attr_accessor :conns
+    def initialize(sz=1)
+      @mutex = Mutex.new
+      @conns = SizedQueue.new(sz)
+      sz.times {@conns.enq(Conn.new)}
+    end
+
+    def use(new_on_empty=true)
+      raise("Expected a block with Pool#use.") unless block_given?
+      c = checkout(new_on_empty)
+      result = nil
+      begin
+        result = yield(c)
+      ensure
+        checkin(c)
+      end
+      return result
+    end
+
+    def drain!
+      until conns.size.zero?
+        c = conns.deq
+        c.disconnect
+      end
+    end
+
+    private
+
+    def checkout(new_on_empty=false)
+      if new_on_empty
+        begin
+          conns.deq(true)
+        rescue ThreadError
+          Conn.new
+        end
+      else
+        conns.deq
+      end
+    end
+
+    def checkin(c)
+      @mutex.synchronize do
+        if conns.size == conns.max
+          c.disconnect
+        else
+          conns.enq(c)
+        end
+      end
+    end
+
+  end
+end

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -1,27 +1,28 @@
 require 'queue_classic'
-require 'queue_classic/conn'
+require 'queue_classic/pool'
 require 'json'
 
 module QC
   class Queue
 
-    attr_reader :name, :top_bound
-    def initialize(name, top_bound=nil)
-      @name = name
-      @top_bound = top_bound || QC::TOP_BOUND
+    attr_reader :pool, :name, :top_bound
+    def initialize(opts={})
+      @pool       = opts[:pool]       || Pool.new
+      @name       = opts[:name]       || QC::QUEUE
+      @top_bound  = opts[:top_bound]  || QC::TOP_BOUND
     end
 
     def enqueue(method, *args)
       QC.log_yield(:measure => 'queue.enqueue') do
         s="INSERT INTO #{TABLE_NAME} (q_name, method, args) VALUES ($1, $2, $3)"
-        res = Conn.execute(s, name, method, JSON.dump(args))
+        res = @pool.use {|c| c.execute(s, name, method, JSON.dump(args))}
       end
     end
 
     def lock
       QC.log_yield(:measure => 'queue.lock') do
         s = "SELECT * FROM lock_head($1, $2)"
-        if r = Conn.execute(s, name, top_bound)
+        if r = @pool.use {|c| c.execute(s, name, top_bound)}
           {:id => r["id"],
             :method => r["method"],
             :args => JSON.parse(r["args"])}
@@ -29,23 +30,30 @@ module QC
       end
     end
 
+    def wait
+      QC.log_yield(:measure => 'queue.wait') do
+        @pool.use {|c| c.wait(name)}
+      end
+    end
+
     def delete(id)
       QC.log_yield(:measure => 'queue.delete') do
-        Conn.execute("DELETE FROM #{TABLE_NAME} where id = $1", id)
+        s = "DELETE FROM #{TABLE_NAME} where id = $1"
+        @pool.use {|c| c.execute(s, id)}
       end
     end
 
     def delete_all
       QC.log_yield(:measure => 'queue.delete_all') do
         s = "DELETE FROM #{TABLE_NAME} WHERE q_name = $1"
-        Conn.execute(s, name)
+        @pool.use {|c| c.execute(s, name)}
       end
     end
 
     def count
       QC.log_yield(:measure => 'queue.count') do
         s = "SELECT COUNT(*) FROM #{TABLE_NAME} WHERE q_name = $1"
-        r = Conn.execute(s, name)
+        r = @pool.use {|c| c.execute(s, name)}
         r["count"].to_i
       end
     end

--- a/lib/queue_classic/setup.rb
+++ b/lib/queue_classic/setup.rb
@@ -5,14 +5,18 @@ module QC
     CreateTable = File.join(Root, "/sql/create_table.sql")
     DropSqlFunctions = File.join(Root, "/sql/drop_ddl.sql")
 
-    def self.create
-      Conn.execute(File.read(CreateTable))
-      Conn.execute(File.read(SqlFunctions))
+    def self.create(pool)
+      pool.use do |c|
+        c.execute(File.read(CreateTable))
+        c.execute(File.read(SqlFunctions))
+      end
     end
 
-    def self.drop
-      Conn.execute("DROP TABLE IF EXISTS queue_classic_jobs CASCADE")
-      Conn.execute(File.read(DropSqlFunctions))
+    def self.drop(pool)
+      pool.use do |c|
+        c.execute("DROP TABLE IF EXISTS queue_classic_jobs CASCADE")
+        c.execute(File.read(DropSqlFunctions))
+      end
     end
   end
 end

--- a/test/conn_test.rb
+++ b/test/conn_test.rb
@@ -2,9 +2,13 @@ require File.expand_path("../helper.rb", __FILE__)
 
 class ConnTest < QCTest
 
+  def setup
+    init_db
+  end
+
   def test_extracts_the_segemnts_to_connect
     database_url = "postgres://ryan:secret@localhost:1234/application_db"
-    normalized = QC::Conn.normalize_db_url(URI.parse(database_url))
+    normalized = QC::Conf.normalized_db_url(URI.parse(database_url))
     assert_equal ["localhost",
                   1234,
                   nil, "",
@@ -15,7 +19,7 @@ class ConnTest < QCTest
 
   def test_regression_database_url_without_host
     database_url = "postgres:///my_db"
-    normalized = QC::Conn.normalize_db_url(URI.parse(database_url))
+    normalized = QC::Conf.normalized_db_url(URI.parse(database_url))
     assert_equal [nil, 5432, nil, "", "my_db", nil, nil], normalized
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,19 +9,12 @@ require "minitest/autorun"
 
 class QCTest < Minitest::Test
 
-  def setup
-    init_db
-  end
-
-  def teardown
-    QC.delete_all
-  end
-
   def init_db
-    QC::Conn.execute("SET client_min_messages TO 'warning'")
-    QC::Setup.drop
-    QC::Setup.create
-    QC::Conn.execute(File.read('./test/helper.sql'))
+    p = QC::Pool.new
+    QC::Setup.drop(p)
+    QC::Setup.create(p)
+    p.use {|c| c.execute(File.read('./test/helper.sql'))}
+    p.drain!
   end
 
   def capture_debug_output

--- a/test/pool_test.rb
+++ b/test/pool_test.rb
@@ -1,0 +1,18 @@
+require File.expand_path("../helper.rb", __FILE__)
+
+class PoolTest < QCTest
+
+  def setup
+    init_db
+  end
+
+  def test_pool_size
+    n = 2
+    p = QC::Pool.new(n)
+    s = 'SELECT count(*) from pg_stat_activity where datname=current_database()'
+    num_conns = p.use {|c| c.execute(s)['count'].to_i}
+    assert_equal(n, num_conns)
+    p.drain!
+  end
+
+end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -26,9 +26,19 @@ end
 
 class WorkerTest < QCTest
 
+  def setup
+    init_db
+    @pool = QC::Pool.new
+  end
+
+  def teardown
+    QC.pool.drain!
+    @pool.drain!
+  end
+
   def test_work
     QC.enqueue("TestObject.no_args")
-    worker = TestWorker.new
+    worker = TestWorker.new(:pool => @pool)
     assert_equal(1, QC.count)
     worker.work
     assert_equal(0, QC.count)
@@ -37,7 +47,7 @@ class WorkerTest < QCTest
 
   def test_failed_job
     QC.enqueue("TestObject.not_a_method")
-    worker = TestWorker.new
+    worker = TestWorker.new(:pool => @pool)
     worker.work
     assert_equal(1, worker.failed_count)
   end
@@ -45,7 +55,7 @@ class WorkerTest < QCTest
   def test_failed_job_is_logged
     output = capture_debug_output do
       QC.enqueue("TestObject.not_a_method")
-      QC::Worker.new.work
+      QC::Worker.new(:pool => @pool).work
     end
     expected_output = /lib=queue-classic at=handle_failure job={:id=>"\d+", :method=>"TestObject.not_a_method", :args=>\[\]} error=#<NoMethodError: undefined method `not_a_method' for TestObject:Module>/
     assert_match(expected_output, output, "=== debug output ===\n #{output}")
@@ -71,7 +81,7 @@ class WorkerTest < QCTest
 
   def test_work_with_no_args
     QC.enqueue("TestObject.no_args")
-    worker = TestWorker.new
+    worker = TestWorker.new(:pool => @pool)
     r = worker.work
     assert_nil(r)
     assert_equal(0, worker.failed_count)
@@ -79,7 +89,7 @@ class WorkerTest < QCTest
 
   def test_work_with_one_arg
     QC.enqueue("TestObject.one_arg", "1")
-    worker = TestWorker.new
+    worker = TestWorker.new(:pool => @pool)
     r = worker.work
     assert_equal("1", r)
     assert_equal(0, worker.failed_count)
@@ -87,39 +97,42 @@ class WorkerTest < QCTest
 
   def test_work_with_two_args
     QC.enqueue("TestObject.two_args", "1", 2)
-    worker = TestWorker.new
+    worker = TestWorker.new(:pool => @pool)
     r = worker.work
     assert_equal(["1", 2], r)
     assert_equal(0, worker.failed_count)
   end
 
   def test_work_custom_queue
-    p_queue = QC::Queue.new("priority_queue")
+    p_queue = QC::Queue.new(:name=> "priority_queue")
     p_queue.enqueue("TestObject.two_args", "1", 2)
-    worker = TestWorker.new(q_name: "priority_queue")
+    worker = TestWorker.new(:pool => @pool, q_name: "priority_queue")
     r = worker.work
     assert_equal(["1", 2], r)
     assert_equal(0, worker.failed_count)
+    p_queue.pool.drain!
   end
 
   def test_worker_listens_on_chan
-    p_queue = QC::Queue.new("priority_queue")
+    p_queue = QC::Queue.new(:name => "priority_queue")
     p_queue.enqueue("TestObject.two_args", "1", 2)
-    worker = TestWorker.new(q_name: "priority_queue", listening_worker: true)
+    worker = TestWorker.new(:pool => @pool, q_name: "priority_queue", listening_worker: true)
     r = worker.work
     assert_equal(["1", 2], r)
     assert_equal(0, worker.failed_count)
+    p_queue.pool.drain!
   end
 
   def test_worker_ueses_one_conn
     QC.enqueue("TestObject.no_args")
-    worker = TestWorker.new
+    worker = TestWorker.new(:pool => @pool)
     worker.work
-    assert_equal(
-      1,
-      QC::Conn.execute("SELECT count(*) from pg_stat_activity where datname = current_database()")["count"].to_i,
-      "Multiple connections found -- are there open connections to #{ QC::Conn.db_url } in other terminals?"
-    )
+    s = 'SELECT count(*) from pg_stat_activity where datname=current_database()'
+    num_conns = QC.pool.use {|c| c.execute(s)["count"].to_i}
+    # One connection for the worker and one for the test.
+    assert_equal(2, num_conns,
+      "Multiple connections found -- are there open connections to" +
+        " #{QC::Conf.db_url} in other terminals?")
   end
 
 end


### PR DESCRIPTION
I have been experimenting with various techniques to add concurrency to the queue_classic worker. So far I have experimented with a threaded worker (#159) and a forking worker. It is worth noting that I had used [threads to manage the forking](https://gist.github.com/ryandotsmith/5940245). In both experiments I needed the ability to work with queue_classic's database connection in thread safe environment. This pull request lays out the foundation for safe, robust connection management so that we can easily build some sort of concurrency in the worker.

@senny I still think your adapter idea will work here. Instead of creating adapters for connection, we will need to create adapters for pools. I am really interested in creating an adapter for active record and for sequel.
