### PR TITLE
Upgrading from an old QC

### DIFF
--- a/lib/queue_classic/setup.rb
+++ b/lib/queue_classic/setup.rb
@@ -18,5 +18,24 @@ module QC
         c.execute(File.read(DropSqlFunctions))
       end
     end
+
+    def self.recreate(poll)
+      poll.use do |c|
+        c.execute <<-SQL
+          SELECT q_name, method, args
+          INTO TEMPORARY old_queue_classic_jobs
+          FROM queue_classic_jobs
+        SQL
+
+        drop pool
+        create pool
+
+        c.execute <<-SQL
+          INSERT INTO queue_classic_jobs (q_name, method, args)
+          SELECT q_name, method, args
+          FROM old_queue_classic_jobs
+        SQL
+      end
+    end
   end
 end


### PR DESCRIPTION
Apparently the QC database schema has changed a bit since I last updated. Below is the diff of my db/structure.sql after running `QC::Setup.drop; QC::Setup.create` locally. Is there a better way to migrate the production database short of hand-coding the `UPDATE TABLE` query?

``` diff
diff --git a/db/structure.sql b/db/structure.sql
index 7f64f8f..7f975f0 100644
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -36,11 +56,13 @@ SET default_with_oids = false;
 --

 CREATE TABLE queue_classic_jobs (
-    id integer NOT NULL,
-    q_name character varying(255),
-    method character varying(255),
-    args text,
-    locked_at timestamp with time zone
+    id bigint NOT NULL,
+    q_name text NOT NULL,
+    method text NOT NULL,
+    args text NOT NULL,
+    locked_at timestamp with time zone,
+    CONSTRAINT queue_classic_jobs_method_check CHECK ((length(method) > 0)),
+    CONSTRAINT queue_classic_jobs_q_name_check CHECK ((length(q_name) > 0))
 );


@@ -65,7 +87,7 @@ CREATE FUNCTION lock_head(q_name character varying, top_boundary integer) RETURN
     LANGUAGE plpgsql
     AS $_$
 DECLARE
-  unlocked integer;
+  unlocked bigint;
   relative_top integer;
   job_count integer;
 BEGIN
@@ -119,6 +141,18 @@ $_$;


 --
+-- Name: queue_classic_notify(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION queue_classic_notify() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$ begin
+  perform pg_notify(new.q_name, '');
+  return null;
+end $$;
+
+
+--
 -- Name: gift_cards; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --

@@ -563,9 +597,18 @@ CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (v


 --
+-- Name: queue_classic_notify; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER queue_classic_notify AFTER INSERT ON queue_classic_jobs FOR EACH ROW EXECUTE PROCEDURE queue_classic_notify();
+
+
+--
```
