### PR TITLE
Documentation fix: reenqueueing failed jobs is described correctly

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ FailedQueue = QC::Queue.new("failed_jobs")
 
 class MyWorker < QC::Worker
  	def handle_failure(job, e)
-		FailedQueue.enqueue(job)
+		FailedQueue.enqueue(job[:method], *job[:args])
  	end
 end
 


### PR DESCRIPTION
`FailedQueue.enqueue(job)` does not work, you have to take the job hash apart and enqueue it again like this: `FailedQueue.enqueue(job[:method], *job[:args])`.
