### PR TITLE
Update pg to 0.17.0

### DIFF
--- a/queue_classic.gemspec
+++ b/queue_classic.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.require_paths = %w[lib]
 
-  s.add_dependency "pg", "~> 0.16.0"
+  s.add_dependency "pg", "~> 0.17.0"
 end


### PR DESCRIPTION
Hi, there is an important bugfix in the new 0.17.0 version of ruby-pg. Queue_classic tests are still passing, no problems occured in runtime. Should be safe to merge. Thanks.
