### PR TITLE
Another pass at multi-queue worker.

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -18,6 +18,7 @@ module QC
   # notes the queue. You can point your workers
   # at different queues but only one at a time.
   QUEUE = ENV["QUEUE"] || "default"
+  QUEUES = ENV["QUEUES"] || []
 
   # Set this to 1 for strict FIFO.
   # There is nothing special about 9....

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -5,6 +5,12 @@ require 'json'
 module QC
   class Queue
 
+    def self.delete(id)
+      QC.log_yield(:measure => 'queue.delete') do
+        Conn.execute("DELETE FROM #{TABLE_NAME} where id = $1", id)
+      end
+    end
+
     attr_reader :name, :top_bound
     def initialize(name, top_bound=nil)
       @name = name
@@ -30,9 +36,7 @@ module QC
     end
 
     def delete(id)
-      QC.log_yield(:measure => 'queue.delete') do
-        Conn.execute("DELETE FROM #{TABLE_NAME} where id = $1", id)
-      end
+      self.class.delete(id)
     end
 
     def delete_all

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Features:
 * Support for multiple queues with heterogeneous workers.
 * JSON data format.
 * Forking workers.
+* Workers can work multiple queues.
 * [Fuzzy-FIFO support](http://www.cs.tau.ac.il/~shanir/nir-pubs-web/Papers/Lock_Free.pdf).
 
 Contents:
@@ -77,6 +78,12 @@ Setup a worker to work a non-default queue.
 
 ```bash
 $ QUEUE="priority_queue" bundle exec rake qc:work
+```
+
+Setup a worker to work multiple queues.
+
+```bash
+$ QUEUE="priority_queue, secondary_queue" bundle exec rake qc:work
 ```
 
 #### Custom Worker


### PR DESCRIPTION
This change is backwards compatible with previous versions.
The worker takes an optional, ordered list of queues to work.
When looking for jobs to lock, the worker will start from the
first queue in the list and work its way down the list looking for a job.
If no jobs are found in the list of queues, the worker will wait on the
listen/notify chanel of the first queue in the list.

The listen/notify behaviour is not ideal. It would be nice if the worker
could linsten to all the queue channels for which it is interested in.
