### PR TITLE
Account for locked_at in job_count query

### DIFF
--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -1,3 +1,8 @@
+--- We are declaring the return type to be queue_classic_jobs.
+--- This is ok since I am assuming that all of the users added queues will
+--- have identical columns to queue_classic_jobs.
+--- When QC supports queues with columns other than the default, we will have to change this.
+
 CREATE OR REPLACE FUNCTION lock_head(q_name varchar, top_boundary integer)
 RETURNS SETOF queue_classic_jobs AS $$
 DECLARE


### PR DESCRIPTION
This prevents relative_count being greater than the number of runnable jobs in the job selection query.

If a queue has locked failed jobs in the table, then lock_head will sometimes return no result based upon its randomly generated offset. The random offset (relative_top) used in the query is greater than the number of runnable jobs in the queue, which causes PG to return no result.

Since job_count is factored into the value of relative_top, fixing its value to be the number of runnable jobs instead of the total number, will cause a result to always be returned if it is available.
