### PR TITLE
Account for locked_at in job_count query

### DIFF
--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -15,7 +15,9 @@ BEGIN
   -- for more workers. Would love to see some optimization here...
 
   EXECUTE 'SELECT count(*) FROM '
-    || '(SELECT * FROM queue_classic_jobs WHERE q_name = '
+    || '(SELECT * FROM queue_classic_jobs '
+    || ' WHERE locked_at IS NULL'
+    || ' AND q_name = '
     || quote_literal(q_name)
     || ' LIMIT '
     || quote_literal(top_boundary)


### PR DESCRIPTION
This prevents relative_count being greater than the number of runnable jobs in the job selection query.

If a queue has locked failed jobs in the table, then lock_head will sometimes return no result based upon its randomly generated offset. The random offset (relative_top) used in the query is greater than the number of runnable jobs in the queue, which causes PG to return no result.

Since job_count is factored into the value of relative_top, fixing its value to be the number of runnable jobs instead of the total number of jobs, will make a result to always be returned if it is available.
