### PR TITLE
Relax job selection if job_count < top_boundary

### DIFF
--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -21,13 +21,13 @@ BEGIN
     || quote_literal(top_boundary)
     || ') limited'
   INTO job_count;
+  
+  IF job_count < top_boundary THEN
+    top_boundary = job_count;
+  END IF;
 
   SELECT TRUNC(random() * (top_boundary - 1))
   INTO relative_top;
-
-  IF job_count < top_boundary THEN
-    relative_top = 0;
-  END IF;
 
   LOOP
     BEGIN


### PR DESCRIPTION
Presently if job_count is less than top_boundary, the first item in the queue is always selected (relative_top = 0). By instead adjusting the top_boundary to be equal to the job_count, a random item will be selected even if the job_count is less than the top_boundary.
