### PR TITLE
Bug: Travis Builds Are Failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ before_script:
   - psql -c 'create database queue_classic_test;' -U postgres
 env:
   - QC_DATABASE_URL="postgres://postgres@localhost/queue_classic_test"
-  - ISOLATED=true
 rvm:
   - 2.1.1
-  - 2.0.0
-  - 1.9.3
 addons:
   postgresql: 9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ before_script:
   - psql -c 'create database queue_classic_test;' -U postgres
 env:
   - QC_DATABASE_URL="postgres://postgres@localhost/queue_classic_test"
+  - ISOLATED=true
 rvm:
   - 2.1.1
   - 2.0.0


### PR DESCRIPTION
Master is currently failing tests on Travis. Specifically, this test is failing... Sometimes.

```
1) Failure:
WorkerTest#test_worker_ueses_one_conn [/home/travis/build/ryandotsmith/queue_classic/test/worker_test.rb:129]:
Multiple connections found -- are there open connections to postgres://postgres@localhost/queue_classic_test in other terminals?.
Expected: 1
  Actual: 2
```

I can't reproduce locally on my machine. I suspect that since we tell travis to run the test on 3 different rubies that there is some overlapping tests which would cause more database connections than we expect.

I also am not sure that this env var `ISOLATED` actually has any effect on travis. I found it on one of their [supports pages](http://docs.travis-ci.com/user/build-configuration/) without any description.