### PR TITLE
handle_failure method gets access to queue from which the failing job originated

### DIFF
--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -47,6 +47,7 @@ module QC
         if r = conn_adapter.execute(s, name, top_bound)
           {}.tap do |job|
             job[:id] = r["id"]
+            job[:q_name] = r["q_name"]
             job[:method] = r["method"]
             job[:args] = JSON.parse(r["args"])
             if r["created_at"]

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -13,10 +13,12 @@ class QueueTest < QCTest
   end
 
   def test_lock
-    QC.enqueue("Klass.method")
-    job = QC.lock
+    queue = QC::Queue.new("queue_classic_jobs")
+    queue.enqueue("Klass.method")
+    job = queue.lock
     # See helper.rb for more information about the large initial id number.
     assert_equal((2**34).to_s, job[:id])
+    assert_equal("queue_classic_jobs", job[:q_name])
     assert_equal("Klass.method", job[:method])
     assert_equal([], job[:args])
   end


### PR DESCRIPTION
This allows failure handling based on the queue the job was scheduled in.
##### An example:

``` ruby
FailureQueue = QC::Queue.new('second_try')

def handle_failure(queue,job,e)
  if queue == FailureQueue
    # The job failed for good, notify airbrake or whatever
    # ...
  else
    # Reschedule the job in the second_try queue
    FailureQueue.enqueue(job[:method], *job[:args])
  end
end
```
