### PR TITLE
207 forking in v3

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -100,7 +100,6 @@ module QC
 
   # before_fork hook (adapted from Unicorn's implementation)
   def self.before_fork(*args, &block)
-    log(:at => "before_fork")
     if block_given?
       DEFAULTS[:before_fork] = block
     else
@@ -110,7 +109,6 @@ module QC
 
   # after_fork hook (adapted from Unicorn's implementation)
   def self.after_fork(*args, &block)
-    log(:at => "after_fork")
     if block_given?
       DEFAULTS[:after_fork] = block
     else
@@ -119,8 +117,8 @@ module QC
   end
 
   DEFAULTS = {
-    :after_fork => lambda {|worker, cpid| },
-    :before_fork => lambda {|worker| }
+    :after_fork => lambda {|worker, cpid| log(:at => "after_fork", :cpid => cpid) },
+    :before_fork => lambda {|worker| log(:at => "before_fork") }
   }
 end
 

--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -97,6 +97,31 @@ module QC
       $stdout.puts("measure#qc.#{data}")
     end
   end
+
+  # before_fork hook (adapted from Unicorn's implementation)
+  def self.before_fork(*args, &block)
+    log(:at => "before_fork")
+    if block_given?
+      DEFAULTS[:before_fork] = block
+    else
+      DEFAULTS[:before_fork].call(*args)
+    end
+  end
+
+  # after_fork hook (adapted from Unicorn's implementation)
+  def self.after_fork(*args, &block)
+    log(:at => "after_fork")
+    if block_given?
+      DEFAULTS[:after_fork] = block
+    else
+      DEFAULTS[:after_fork].call(*args)
+    end
+  end
+
+  DEFAULTS = {
+    :after_fork => lambda {|worker, cpid| },
+    :before_fork => lambda {|worker| }
+  }
 end
 
 require_relative "queue_classic/queue"

--- a/lib/queue_classic/conn_adapter.rb
+++ b/lib/queue_classic/conn_adapter.rb
@@ -11,7 +11,12 @@ module QC
       @mutex = Mutex.new
     end
 
+    def reconnect_if_closed
+     @connection = establish_new
+    end
+
     def execute(stmt, *params)
+      reconnect_if_closed
       @mutex.synchronize do
         QC.log(:at => "exec_sql", :sql => stmt.inspect)
         begin

--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -60,19 +60,12 @@ module QC
     # Calls Worker#work but after the current process is forked.
     # The parent process will wait on the child process to exit.
     def fork_and_work
-      read, write = IO.pipe
       before_fork
-      cpid = Process.fork do
-        setup_child
-        read.close
-        write.puts work
-      end
+      cpid = fork {setup_child; work}
       log(:at => :fork, :pid => cpid)
-      write.close
       Process.wait(cpid)
       @running = false
       after_fork(cpid)
-      read.read.strip
     end
 
     # Override if you want to run code before a forked worker

--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -41,7 +41,7 @@ module QC
     def start
       unlock_jobs_of_dead_workers()
       while @running
-       @fork_worker ? fork_and_work : work
+        @fork_worker ? fork_and_work : work
       end
     end
 
@@ -63,7 +63,6 @@ module QC
       cpid = fork {setup_child; work}
       log(:at => :fork, :pid => cpid)
       Process.wait(cpid)
-      @running = false
       QC.after_fork(self, cpid)
       cpid
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,7 +5,6 @@ ENV["DATABASE_URL"] ||= "postgres:///queue_classic_test"
 
 require "queue_classic"
 require "stringio"
-require 'minitest'
 require "minitest/autorun"
 
 class QCTest < Minitest::Test

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,6 +5,7 @@ ENV["DATABASE_URL"] ||= "postgres:///queue_classic_test"
 
 require "queue_classic"
 require "stringio"
+require 'minitest'
 require "minitest/autorun"
 
 class QCTest < Minitest::Test

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -197,10 +197,10 @@ class WorkerTest < QCTest
   def test_forked_worker
     # create hooks for logging
     QC.before_fork do |worker|
-      QC.log(:before_fork => "true")
+      QC.log(:testing_before_fork => "true")
     end
     QC.after_fork do |worker, cpid|
-      QC.log(:after_fork => cpid)
+      QC.log(:testing_after_fork => cpid)
     end
 
     #run a simple forked job
@@ -212,9 +212,9 @@ class WorkerTest < QCTest
     end
 
     assert_equal(0, forking_worker.failed_count)
-    expected_output = /lib=queue-classic before_fork=true/
+    expected_output = /lib=queue-classic testing_before_fork=true/
     assert_match(expected_output, output, "=== debug output ===\n #{output}")
-    expected_output = /lib=queue-classic after_fork=#{cpid}/
+    expected_output = /lib=queue-classic testing_after_fork=#{cpid}/
     assert_match(expected_output, output, "=== debug output ===\n #{output}")
   end
 end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -197,7 +197,7 @@ class WorkerTest < QCTest
   def test_forked_worker
     QC.enqueue("TestObject.one_arg", "13")
     worker = TestWorker.new(:fork_worker => true)
-    r = worker.start
-    assert_equal("13", r)
+    cpid = worker.start
+    assert_equal(0, worker.failed_count)
   end
 end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -194,4 +194,10 @@ class WorkerTest < QCTest
     assert_equal(1, res.count)
   end
 
+  def test_forked_worker
+    QC.enqueue("TestObject.one_arg", "13")
+    worker = TestWorker.new(:fork_worker => true)
+    r = worker.start
+    assert_equal("13", r)
+  end
 end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -205,12 +205,13 @@ class WorkerTest < QCTest
 
     #run a simple forked job
     QC.enqueue("TestObject.no_args")
+    QC.enqueue("TestObject.no_args")
     forking_worker = TestWorker.new(:fork_worker => true)
     cpid = nil
     output = capture_debug_output do
       cpid = forking_worker.fork_and_work
     end
-
+    forking_worker.fork_and_work
     assert_equal(0, forking_worker.failed_count)
     expected_output = /lib=queue-classic testing_before_fork=true/
     assert_match(expected_output, output, "=== debug output ===\n #{output}")


### PR DESCRIPTION
Tries to fix #207

When a worker forks, the forked process inherits its master connection. Then, after the forked process is finished (exactly where I can't pinpoint), the master connection closes.
At least in the test suite, the teardown function deletes all jobs, and that's when a PG::UnableToSend error pulls up.

The weird thing is that when I check the connection's status, and the connect_poll property (which ActiveRecord uses to check PG connections), they're both fine. The only way -yet- that I can tell the connection's broken is to execute and handle the PGError.

My current solution is to check the PGError for "PG::UnableToSend", and if true then reconnect and re-execute the query. I'm still hoping to find out exactly when the connection closed, without relying on an error.

I also added `QC.before_fork do |worker|` and `QC.after_fork do |worker, cpid|` hooks like Unicorn has, and a test to cover the connection problem and the hooks.
