### PR TITLE
Support for scheduling jobs in the future

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ p_queue = QC::Queue.new("priority_queue")
 p_queue.enqueue("Kernel.puts", ["hello", "world"])
 ```
 
+There is also the possibility to schedule a job at a specified time in the future. It will not be worked off before that specified time.
+
+```ruby
+# Specifying the job execution time exactly.
+QC.enqueue_at(Time.new(2024,01,02,10,00), "Kernel.puts", "hello future")
+
+# Specifying the job execution time as an offset in seconds.
+QC.enqueue_in(60, "Kernel.puts", "hello from 1 minute later")
+```
+
 ### Working Jobs
 
 There are two ways to work jobs. The first approach is to use the Rake task. The second approach is to use a custom executable.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ queue_classic provides a simple interface to a PostgreSQL-backed message queue. 
 * [Documentation](http://rubydoc.info/gems/queue_classic/2.2.3/frames)
 * [Usage](#usage)
 * [Setup](#setup)
-* [Upgrade from V2 to V3](#upgrade-from-v2-to-v3)
+* [Upgrade from earlier versions to V3.1](#upgrade-from-earlier-versions)
 * [Configuration](#configuration)
   * [JSON](#json)
   * [Logging](#logging)
@@ -201,7 +201,7 @@ If you don't want to use the automatic database connection, set this environment
 
 By default, queue_classic will use the QC_DATABASE_URL falling back on DATABASE_URL. The URL must be in the following format: `postgres://username:password@localhost/database_name`.  If you use Heroku's PostgreSQL service, this will already be set. If you don't want to set this variable, you can set the connection in an initializer. **QueueClassic will maintain its own connection to the database.** This may double the number of connections to your database.
 
-## Upgrade from V2 to V3
+## Upgrade from earlier versions
 If you are upgrading from a previous version of queue_classic, you might need some new database columns and/or functions. Luckily enough for you, it is easy to do so.
 
 ### Ruby on Rails

--- a/lib/generators/queue_classic/install_generator.rb
+++ b/lib/generators/queue_classic/install_generator.rb
@@ -27,6 +27,10 @@ module QC
       if self.class.migration_exists?('db/migrate', 'update_queue_classic_3_0_2').nil?
         migration_template 'update_queue_classic_3_0_2.rb', 'db/migrate/update_queue_classic_3_0_2.rb'
       end
+
+      if self.class.migration_exists?('db/migrate', 'update_queue_classic_3_1_0').nil?
+        migration_template 'update_queue_classic_3_1_0.rb', 'db/migrate/update_queue_classic_3_1_0.rb'
+      end
     end
   end
 end

--- a/lib/generators/queue_classic/templates/update_queue_classic_3_1_0.rb
+++ b/lib/generators/queue_classic/templates/update_queue_classic_3_1_0.rb
@@ -1,0 +1,9 @@
+class UpdateQueueClassic310 < ActiveRecord::Migration
+  def self.up
+    QC::Setup.update_to_3_1_0
+  end
+
+  def self.down
+    QC::Setup.downgrade_from_3_1_0
+  end
+end

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -41,11 +41,21 @@ module QC
       end
     end
 
+    # enqueue_at(t,m,a) inserts a row into the jobs table representing a job
+    # to be executed not before the specified time.
+    # The time argument must be a Time object. The method and args argument
+    # must be in the form described in the documentation for the #enqueue
+    # method.
     def enqueue_at(time, method, *args)
       offset = time - Time.now
       enqueue_in(offset, method, *args)
     end
 
+    # enqueue_in(t,m,a) inserts a row into the jobs table representing a job
+    # to be executed not before the specified time offset.
+    # The seconds argument must be a number. The method and args argument
+    # must be in the form described in the documentation for the #enqueue
+    # method.
     def enqueue_in(seconds, method, *args)
       QC.log_yield(:measure => 'queue.enqueue') do
         s = "INSERT INTO #{TABLE_NAME} (q_name, method, args, created_at)

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -53,7 +53,7 @@ module QC
 
     # enqueue_in(t,m,a) inserts a row into the jobs table representing a job
     # to be executed not before the specified time offset.
-    # The seconds argument must be a number. The method and args argument
+    # The seconds argument must be an integer. The method and args argument
     # must be in the form described in the documentation for the #enqueue
     # method.
     def enqueue_in(seconds, method, *args)

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -41,6 +41,13 @@ module QC
       end
     end
 
+    def enqueue_at(time, method, *args)
+      QC.log_yield(:measure => 'queue.enqueue') do
+        s="INSERT INTO #{TABLE_NAME} (q_name, method, args, created_at) VALUES ($1, $2, $3, $4)"
+        res = conn_adapter.execute(s, name, method, JSON.dump(args), time)
+      end
+    end
+
     def lock
       QC.log_yield(:measure => 'queue.lock') do
         s = "SELECT * FROM lock_head($1, $2)"

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -43,11 +43,11 @@ module QC
 
     # enqueue_at(t,m,a) inserts a row into the jobs table representing a job
     # to be executed not before the specified time.
-    # The time argument must be a Time object. The method and args argument
-    # must be in the form described in the documentation for the #enqueue
-    # method.
-    def enqueue_at(time, method, *args)
-      offset = time - Time.now
+    # The time argument must be a Time object or a float timestamp. The method
+    # and args argument must be in the form described in the documentation for
+    # the #enqueue method.
+    def enqueue_at(timestamp, method, *args)
+      offset = Time.at(timestamp) - Time.now
       enqueue_in(offset, method, *args)
     end
 

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -58,7 +58,7 @@ module QC
     # method.
     def enqueue_in(seconds, method, *args)
       QC.log_yield(:measure => 'queue.enqueue') do
-        s = "INSERT INTO #{TABLE_NAME} (q_name, method, args, created_at)
+        s = "INSERT INTO #{TABLE_NAME} (q_name, method, args, scheduled_at)
              VALUES ($1, $2, $3, now() + interval '#{seconds.to_i} seconds')"
         res = conn_adapter.execute(s, name, method, JSON.dump(args))
       end
@@ -73,9 +73,9 @@ module QC
             job[:q_name] = r["q_name"]
             job[:method] = r["method"]
             job[:args] = JSON.parse(r["args"])
-            if r["created_at"]
-              job[:created_at] = Time.parse(r["created_at"])
-              ttl = Integer((Time.now - job[:created_at]) * 1000)
+            if r["scheduled_at"]
+              job[:scheduled_at] = Time.parse(r["scheduled_at"])
+              ttl = Integer((Time.now - job[:scheduled_at]) * 1000)
               QC.measure("time-to-lock=#{ttl}ms source=#{name}")
             end
           end

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -42,9 +42,15 @@ module QC
     end
 
     def enqueue_at(time, method, *args)
+      offset = time - Time.now
+      enqueue_in(offset, method, *args)
+    end
+
+    def enqueue_in(seconds, method, *args)
       QC.log_yield(:measure => 'queue.enqueue') do
-        s="INSERT INTO #{TABLE_NAME} (q_name, method, args, created_at) VALUES ($1, $2, $3, $4)"
-        res = conn_adapter.execute(s, name, method, JSON.dump(args), time)
+        s = "INSERT INTO #{TABLE_NAME} (q_name, method, args, created_at)
+             VALUES ($1, $2, $3, now() + interval '#{seconds.to_i} seconds')"
+        res = conn_adapter.execute(s, name, method, JSON.dump(args))
       end
     end
 

--- a/lib/queue_classic/setup.rb
+++ b/lib/queue_classic/setup.rb
@@ -6,6 +6,8 @@ module QC
     DropSqlFunctions = File.join(Root, "/sql/drop_ddl.sql")
     UpgradeTo_3_0_0 = File.join(Root, "/sql/update_to_3_0_0.sql")
     DowngradeFrom_3_0_0 = File.join(Root, "/sql/downgrade_from_3_0_0.sql")
+    UpgradeTo_3_1_0 = File.join(Root, "/sql/update_to_3_1_0.sql")
+    DowngradeFrom_3_1_0 = File.join(Root, "/sql/downgrade_from_3_1_0.sql")
 
     def self.create(c = QC::default_conn_adapter.connection)
       conn = QC::ConnAdapter.new(c)
@@ -24,6 +26,7 @@ module QC
     def self.update(c = QC::default_conn_adapter.connection)
       conn = QC::ConnAdapter.new(c)
       conn.execute(File.read(UpgradeTo_3_0_0))
+      conn.execute(File.read(UpgradeTo_3_1_0))
       conn.execute(File.read(DropSqlFunctions))
       conn.execute(File.read(SqlFunctions))
     end
@@ -38,6 +41,18 @@ module QC
     def self.downgrade_from_3_0_0(c = QC::default_conn_adapter.connection)
       conn = QC::ConnAdapter.new(c)
       conn.execute(File.read(DowngradeFrom_3_0_0))
+    end
+
+    def self.update_to_3_1_0(c = QC::default_conn_adapter.connection)
+      conn = QC::ConnAdapter.new(c)
+      conn.execute(File.read(UpgradeTo_3_1_0))
+      conn.execute(File.read(DropSqlFunctions))
+      conn.execute(File.read(SqlFunctions))
+    end
+
+    def self.downgrade_from_3_1_0(c = QC::default_conn_adapter.connection)
+      conn = QC::ConnAdapter.new(c)
+      conn.execute(File.read(DowngradeFrom_3_1_0))
     end
   end
 end

--- a/sql/create_table.sql
+++ b/sql/create_table.sql
@@ -7,7 +7,8 @@ CREATE TABLE queue_classic_jobs (
   args   text not null,
   locked_at timestamptz,
   locked_by integer,
-  created_at timestamptz default now()
+  created_at timestamptz default now(),
+  scheduled_at timestamptz default now()
 );
 
 -- If json type is available, use it for the args column.
@@ -19,3 +20,5 @@ end if;
 end $$ language plpgsql;
 
 CREATE INDEX idx_qc_on_name_only_unlocked ON queue_classic_jobs (q_name, id) WHERE locked_at IS NULL;
+CREATE INDEX idx_qc_on_scheduled_at_only_unlocked ON queue_classic_jobs (scheduled_at, id) WHERE locked_at IS NULL;
+

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -19,7 +19,7 @@ BEGIN
     || ' WHERE locked_at IS NULL'
     || ' AND q_name = '
     || quote_literal(q_name)
-    || ' AND created_at <= '
+    || ' AND scheduled_at <= '
     || quote_literal(now())
     || ' LIMIT '
     || quote_literal(top_boundary)
@@ -39,7 +39,7 @@ BEGIN
         || ' WHERE locked_at IS NULL'
         || ' AND q_name = '
         || quote_literal(q_name)
-        || ' AND created_at <= '
+        || ' AND scheduled_at <= '
         || quote_literal(now())
         || ' ORDER BY id ASC'
         || ' LIMIT 1'

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -19,6 +19,8 @@ BEGIN
     || ' WHERE locked_at IS NULL'
     || ' AND q_name = '
     || quote_literal(q_name)
+    || ' AND created_at <= '
+    || quote_literal(now())
     || ' LIMIT '
     || quote_literal(top_boundary)
     || ') limited'
@@ -37,6 +39,8 @@ BEGIN
         || ' WHERE locked_at IS NULL'
         || ' AND q_name = '
         || quote_literal(q_name)
+        || ' AND created_at <= '
+        || quote_literal(now())
         || ' ORDER BY id ASC'
         || ' LIMIT 1'
         || ' OFFSET ' || quote_literal(relative_top)

--- a/sql/downgrade_from_3_1_0.sql
+++ b/sql/downgrade_from_3_1_0.sql
@@ -1,0 +1,1 @@
+ALTER TABLE queue_classic_jobs DROP COLUMN scheduled_at;

--- a/sql/update_to_3_1_0.sql
+++ b/sql/update_to_3_1_0.sql
@@ -1,0 +1,9 @@
+DO $$DECLARE r record;
+BEGIN
+	BEGIN
+		ALTER TABLE queue_classic_jobs ADD COLUMN scheduled_at timestamptz default now();
+		CREATE INDEX idx_qc_on_scheduled_at_only_unlocked ON queue_classic_jobs (scheduled_at, id) WHERE locked_at IS NULL;
+	EXCEPTION
+		WHEN duplicate_column THEN RAISE NOTICE 'column scheduled_at already exists in queue_classic_jobs.';
+	END;
+END$$;

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -36,11 +36,21 @@ class QueueTest < QCTest
     assert_equal([], job[:args])
   end
 
-  def test_lock_with_future_job_with_enqueue_at
+  def test_lock_with_future_job_with_enqueue_at_with_a_time_object
     future = Time.now + 2
     QC.enqueue_at(future, "Klass.method")
     assert_nil QC.lock
     until Time.now >= future do sleep 0.1 end
+    job = QC.lock
+    assert_equal("Klass.method", job[:method])
+    assert_equal([], job[:args])
+  end
+
+  def test_lock_with_future_job_with_enqueue_at_with_a_float_timestamp
+    offset = (Time.now + 2).to_f
+    QC.enqueue_at(offset, "Klass.method")
+    assert_nil QC.lock
+    sleep 2
     job = QC.lock
     assert_equal("Klass.method", job[:method])
     assert_equal([], job[:args])

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -28,10 +28,19 @@ class QueueTest < QCTest
   end
 
   def test_lock_with_future_job
-    future = Time.now + 3
+    QC.enqueue_in(2, "Klass.method")
+    assert_nil QC.lock
+    sleep 2
+    job = QC.lock
+    assert_equal("Klass.method", job[:method])
+    assert_equal([], job[:args])
+  end
+
+  def test_lock_with_future_job_alternative_api
+    future = Time.now + 2
     QC.enqueue_at(future, "Klass.method")
     assert_nil QC.lock
-    until Time.now >= future do sleep 1 end
+    until Time.now >= future do sleep 0.1 end
     job = QC.lock
     assert_equal("Klass.method", job[:method])
     assert_equal([], job[:args])

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -27,6 +27,16 @@ class QueueTest < QCTest
     assert_nil(QC.lock)
   end
 
+  def test_lock_with_future_job
+    future = Time.now + 3
+    QC.enqueue_at(future, "Klass.method")
+    assert_nil QC.lock
+    until Time.now >= future do sleep 1 end
+    job = QC.lock
+    assert_equal("Klass.method", job[:method])
+    assert_equal([], job[:args])
+  end
+
   def test_count
     QC.enqueue("Klass.method")
     assert_equal(1, QC.count)

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -27,7 +27,7 @@ class QueueTest < QCTest
     assert_nil(QC.lock)
   end
 
-  def test_lock_with_future_job
+  def test_lock_with_future_job_with_enqueue_in
     QC.enqueue_in(2, "Klass.method")
     assert_nil QC.lock
     sleep 2
@@ -36,7 +36,7 @@ class QueueTest < QCTest
     assert_equal([], job[:args])
   end
 
-  def test_lock_with_future_job_alternative_api
+  def test_lock_with_future_job_with_enqueue_at
     future = Time.now + 2
     QC.enqueue_at(future, "Klass.method")
     assert_nil QC.lock


### PR DESCRIPTION
I think having the ability to schedule a job for execution after a given point in time is a crucial feature for a background processing system.
At the moment, this is possible with *queue_classic* only by using [queue_classic-later](https://github.com/dpiddy/queue_classic-later), which is quite clunky to use (you need a second database table and a tick process).

So I quickly implemented a very minimal solution that uses the already existing *created_at* column of the jobs table to specify the time by which a job may be executed.

##### Example:

```ruby
# schedule a job in 10 seconds
QC.enqueue_at Time.now + 10, 'Kernel.puts'
# job is not being locked at this point in time
QC.lock # => nil
# when you wait (at least) 10 seconds...
sleep 10
# job can be locked now
QC.lock # => {method: 'Kernel.puts', ...}

# scheduling a job without a time constraint
# works just as it used to
QC.enqueue 'Kernel.print'
QC.lock # => {method: 'Kernel.print', ...}
```

What do you think? Is this feature generally a useful addition? If yes: is the implementation/API ok or would there be a better solution?


*Note: this pull request would need some more work (e.g. documentation) which I would gladly provide/improve, if you decide that you want this feature...*