### PR TITLE
Fixes forking for workers. Should not corrupt pg connection anymore.

### DIFF
--- a/lib/queue_classic/conn_adapter.rb
+++ b/lib/queue_classic/conn_adapter.rb
@@ -7,11 +7,13 @@ module QC
 
     attr_accessor :connection
     def initialize(c=nil)
+      @pid = Process.pid
       @connection = c.nil? ? establish_new : validate!(c)
       @mutex = Mutex.new
     end
 
     def execute(stmt, *params)
+      raise "Forked workers should create a new DB connection" unless @pid == Process.pid 
       @mutex.synchronize do
         QC.log(:at => "exec_sql", :sql => stmt.inspect)
         begin


### PR DESCRIPTION
Alternative solution for #207 forking

To achieve correct forking, all SQL-queries are moved out to the parent process, so child process only does the workload and marshals result back to parent process. Forked workers should NOT re-use parent connection (sanity check added).

The code makes use of exit!(0) command, that triggers fast exit from a forked process, so postgres does not have a chance to close the connection.

Adds specs for forked workers success/failure, mixed workers, connection reuse exception.
