### PR TITLE
Asynchronous forked workers with specs

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -31,7 +31,7 @@ module QC
   # for more details.
   FORK_WORKER = !ENV["QC_FORK_WORKER"].nil?
 
-  # Should forked worker wait for response by default?
+  # When worker forks, should parent process wait for its completion?
   ASYNCHRONOUS_WORKER = !ENV["QC_ASYNCHRONOUS_WORKER"].nil?
 
   # Defer method calls on the QC module to the

--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -31,6 +31,9 @@ module QC
   # for more details.
   FORK_WORKER = !ENV["QC_FORK_WORKER"].nil?
 
+  # Should forked worker wait for response by default?
+  ASYNCHRONOUS_WORKER = !ENV["QC_ASYNCHRONOUS_WORKER"].nil?
+
   # Defer method calls on the QC module to the
   # default queue. This facilitates QC.enqueue()
   def self.method_missing(sym, *args, &block)

--- a/lib/queue_classic/conn_adapter.rb
+++ b/lib/queue_classic/conn_adapter.rb
@@ -7,10 +7,6 @@ module QC
     attr_accessor :connection
 
     def initialize(c=nil)
-      establish(c)
-    end
-
-    def establish(c = nil)
       @pid = Process.pid
       @connection = c.nil? ? establish_new : validate!(c)
       @mutex = Mutex.new
@@ -19,7 +15,7 @@ module QC
     def dont_use_forked_connection(pid = Process.pid)
       unless @pid == pid
         @pid = pid
-        establish
+        initialize
       end
     end
 

--- a/lib/queue_classic/conn_adapter.rb
+++ b/lib/queue_classic/conn_adapter.rb
@@ -7,11 +7,13 @@ module QC
 
     attr_accessor :connection
     def initialize(c=nil)
+      @pid = Process.pid
       @connection = c.nil? ? establish_new : validate!(c)
       @mutex = Mutex.new
     end
 
     def execute(stmt, *params)
+      raise "Forked workers should create a new DB connection" unless @pid == Process.pid 
       @mutex.synchronize do
         QC.log(:at => "exec_sql", :sql => stmt.inspect)
         begin

--- a/lib/queue_classic/conn_adapter.rb
+++ b/lib/queue_classic/conn_adapter.rb
@@ -15,6 +15,7 @@ module QC
     def reestablish
       @connection = establish_new;
       @mutex = Mutex.new
+      @pid = Process.pid
     end
 
     def needs_its_own_connection?

--- a/lib/queue_classic/conn_adapter.rb
+++ b/lib/queue_classic/conn_adapter.rb
@@ -7,16 +7,17 @@ module QC
     attr_accessor :connection
 
     def initialize(c=nil)
+      establish(c)
+    end
+
+    def establish(c=nil)
       @pid = Process.pid
       @connection = c.nil? ? establish_new : validate!(c)
       @mutex = Mutex.new
     end
 
-    def dont_use_forked_connection(pid = Process.pid)
-      unless @pid == pid
-        @pid = pid
-        initialize
-      end
+    def dont_use_forked_connection
+      establish unless @pid == Process.pid
     end
 
     def execute(stmt, *params)

--- a/lib/queue_classic/conn_adapter.rb
+++ b/lib/queue_classic/conn_adapter.rb
@@ -12,8 +12,18 @@ module QC
       @mutex = Mutex.new
     end
 
+    def reestablish
+      @connection = establish_new;
+      @mutex = Mutex.new
+    end
+
+    def needs_its_own_connection?
+      @pid != Process.pid
+    end
+
     def execute(stmt, *params)
-      raise "Forked workers should create a new DB connection" unless @pid == Process.pid 
+      reestablish if needs_its_own_connection?
+
       @mutex.synchronize do
         QC.log(:at => "exec_sql", :sql => stmt.inspect)
         begin

--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -23,8 +23,6 @@ module QC
 
       if args[:connection]
         @conn_adapter = ConnAdapter.new(args[:connection])
-      elsif @asynchronous
-        @conn_adapter = QC.default_conn_adapter
       elsif QC.has_connection?
         @conn_adapter = QC.default_conn_adapter
       end
@@ -107,7 +105,6 @@ module QC
     def process(queue, job, &callback)
       start = Time.now
       call(job, callback) do |result|
-        queue.conn_adapter.dont_use_forked_connection
         log_result(queue, job, result, start)
       end
     end

--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -153,9 +153,12 @@ module QC
     end
 
     # Invoke worker inside a forked process. Worker should NOT
-    # use shared pg connection, as it corrupts it. It pipes the 
-    # result back via IO.pipe, passes exceptions through.
-    # To use pg inside worker, use connection pool or a fresh connection
+    # use shared pg connection, as it corrupts it. Worker clones
+    # connection for you behind the scenes if you try to execute
+    # anything in conn_adapter. The forked process pipes the result 
+    # back via IO.pipe and re-raises exceptions. If a worker is
+    # asynchronous, it returns pid as output and logs completion on
+    # its own.
     def call_forked(job, callback = nil)
       read, write = IO.pipe
       prepare_child

--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -111,6 +111,7 @@ module QC
       end
     end
 
+    # If a result is not Exception, the job is considered a success
     def log_result(queue, job, result, start)
       ttp = Integer((Time.now - start) * 1000)
       QC.measure("time-to-process=#{ttp} source=#{queue.name}")

--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -10,6 +10,7 @@ module QC
     # Creates a new worker but does not start the worker. See Worker#start.
     # This method takes a single hash argument. The following keys are read:
     # fork_worker:: Worker forks each job execution.
+    # asynchronous:: When true, the parent process doesnt wait for forks
     # wait_interval:: Time to wait between failed lock attempts
     # connection:: PGConn object.
     # q_name:: Name of a single queue to process.
@@ -18,9 +19,12 @@ module QC
     def initialize(args={})
       @fork_worker = args[:fork_worker] || QC::FORK_WORKER
       @wait_interval = args[:wait_interval] || QC::WAIT_TIME
+      @asynchronous = args[:asynchronous] || QC::ASYNCHRONOUS_WORKER
 
       if args[:connection]
         @conn_adapter = ConnAdapter.new(args[:connection])
+      elsif @asynchronous
+        @conn_adapter = QC.default_conn_adapter
       elsif QC.has_connection?
         @conn_adapter = QC.default_conn_adapter
       end
@@ -58,11 +62,11 @@ module QC
 
     # Blocks on locking a job, and once a job is locked,
     # it will process the job.
-    def work
+    def work(&block)
       queue, job = lock_job
       if queue && job
         QC.log_yield(:at => "work", :job => job[:id]) do
-          process(queue, job)
+          process(queue, job, &block)
         end
       end
     end
@@ -100,31 +104,48 @@ module QC
     # to do with the job is delegated to Worker#handle_failure.
     # If the job is not finished and an INT signal is traped,
     # this method will unlock the job in the queue.
-    def process(queue, job)
+    def process(queue, job, &callback)
       start = Time.now
-      finished = false
-      begin
-        result = @fork_worker ? call_forked(job) : call(job)
-        result.tap do
-          queue.delete(job[:id])
-          finished = true
-        end
-      rescue => e
-        handle_failure(job, e)
-        finished = true
-      ensure
-        if !finished
-          queue.unlock(job[:id])
-        end
-        ttp = Integer((Time.now - start) * 1000)
-        QC.measure("time-to-process=#{ttp} source=#{queue.name}")
+      call(job, callback) do |result|
+        log_result(queue, job, result, start)
+        result
       end
+    end
+
+    def log_result(queue, job, result, start)
+      ttp = Integer((Time.now - start) * 1000)
+      QC.measure("time-to-process=#{ttp} source=#{queue.name}")
+      if (Exception === result)
+        log_failure(queue, job, result)
+      else
+        log_success(queue, job, result)
+      end
+      result
+    end
+
+    def log_failure(queue, job, result)
+      queue.unlock(job[:id])
+      handle_failure(job, result)
+    end
+
+    def log_success(queue, job, result)
+      queue.delete(job[:id])
+    end
+
+    def call(job, callback = nil, &block)
+      if @fork_worker
+        call_forked(job, callback, &block)
+      else
+        yield call_inline(job)
+      end
+    rescue => e
+      yield e 
     end
 
     # Each job includes a method column. We will use ruby's eval
     # to grab the ruby object from memory. We send the method to
     # the object and pass the args.
-    def call(job)
+    def call_inline(job)
       args = job[:args]
       receiver_str, _, message = job[:method].rpartition('.')
       receiver = eval(receiver_str)
@@ -135,30 +156,38 @@ module QC
     # use shared pg connection, as it corrupts it. It pipes the 
     # result back via IO.pipe, passes exceptions through.
     # To use pg inside worker, use connection pool or a fresh connection
-    def call_forked(job)
+    def call_forked(job, callback = nil)
       read, write = IO.pipe
       prepare_child
-      cpid = fork do
-        read.close
+      fork_pid = fork do
         setup_child
         begin
-          result = call(job)
+          result = call_inline(job)
         rescue => e
           result = e
         ensure
-          Marshal.dump(result, write)
+          callback.call(result) if callback
+          # Asynchronous workers should log completion on their own
+          if @asynchronous
+            yield result
+          else
+            read.close
+            Marshal.dump(result, write)
+          end
           # Exit forked process without running exit handlers 
           # so pg connection is not corrupted
           exit!(0) 
         end
       end
-      log(:at => :fork, :pid => cpid)
-      write.close
-      result = read.read
-      Process.wait(cpid)
-      loaded = Marshal.load(result)
-      raise loaded if Exception === loaded
-      loaded
+      log(:at => :fork, :pid => fork_pid)
+      unless @asynchronous
+        write.close
+        marshalled = read.read
+        Process.wait(fork_pid)
+        yield Marshal.load(marshalled)
+      else
+        fork_pid
+      end
     end
 
     # This method will be called when an exception
@@ -171,7 +200,9 @@ module QC
     # your worker is forking and you need to
     # re-establish database connections
     def setup_child
-      
+      if @asynchronous && QC.default_conn_adapter.needs_its_own_connection?
+        QC.default_conn_adapter.reestablish
+      end
     end
 
     # This method is called before process is forked

--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -183,13 +183,12 @@ module QC
       fork_pid = fork do
         setup_child
         result = call_inline(job, callback, &block)
-        # Asynchronous workers should log completion on their own
         unless @asynchronous
           read.close
           Marshal.dump(result, write)
         end
         # Exit forked process without running exit handlers 
-        # so pg connection is not corrupted
+        # so pg connection in parent process doesnt break
         exit!(0) 
       end
       log(:at => :fork, :pid => fork_pid)

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -311,22 +311,15 @@ class WorkerTest < QCTest
     sync2 = TestWorker.new
 
 
-    assert_equal(6, QC.count) # not yet executed
-    f1 = fork1.work
-    assert_equal(5, QC.count) # executed synchronously
-    f2 = fork2.work
-    assert_equal(4, QC.count) # executed synchronously
-
     a1 = async1.work
     a2 = async2.work
-    assert_equal(4, QC.count) # not yet executed
+    
+    f1 = fork1.work
+    f2 = fork2.work
 
     s1 = sync1.work
-    assert_equal(3, QC.count) # executed synchronously
     s2 = sync2.work
-    assert_equal(2, QC.count) # executed synchronously
 
-    assert_equal(2, QC.count) # async not done here
     Process.wait(a1)
     Process.wait(a2)
     assert_equal(0, QC.count) # all done

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -127,10 +127,11 @@ class WorkerTest < QCTest
   end
 
   def test_worker_reuses_conn
-    QC.enqueue("TestObject.no_args")
+    QC.enqueue("QC.default_conn_adapter.execute", "SELECT 123 as value")
     count = QC.default_conn_adapter.execute("SELECT count(*) from pg_stat_activity where datname = current_database()")["count"].to_i;
     worker = TestWorker.new
-    worker.work
+    result = worker.work
+    assert_equal("123", result["value"])
     new_count = QC.default_conn_adapter.execute("SELECT count(*) from pg_stat_activity where datname = current_database()")["count"].to_i;
     assert(
       new_count == count,

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -329,7 +329,7 @@ class WorkerTest < QCTest
     assert_equal(2, QC.count) # async not done here
     Process.wait(a1)
     Process.wait(a2)
-    assert_equal(0, QC.count) # not yet executed
+    assert_equal(0, QC.count) # all done
 
   end
 

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -234,7 +234,7 @@ class WorkerTest < QCTest
   end
 
 
-  def test_forked_work_that_does_no_sql
+  def test_forked_work_that_does_sql
     QC.enqueue("TestObject.qc_count")
     worker = TestWorker.new fork_worker: true
     read, write = IO.pipe

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -316,13 +316,10 @@ class WorkerTest < QCTest
     a1 = async1.work
     a2 = async2.work
     
-    count = QC.default_conn_adapter.execute("SELECT count(*) from pg_stat_activity where datname = current_database()")["count"].to_i;
     f1 = fork1.work
     f2 = fork2.work
     s1 = sync1.work
     s2 = sync2.work
-    new_count = QC.default_conn_adapter.execute("SELECT count(*) from pg_stat_activity where datname = current_database()")["count"].to_i;
-    assert(new_count == count)
     
     Process.wait(a1)
     Process.wait(a2)

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -240,11 +240,11 @@ class WorkerTest < QCTest
     QC.enqueue("TestObject.qc_count")
     worker = TestWorker.new fork_worker: true
     read, write = IO.pipe
-    object_id = QC.default_conn_adapter.connection.object_id
+    object_id = QC.default_queue.conn_adapter.connection.object_id
     assert_equal(1, QC.count)
     output = worker.work do
       read.close
-      Marshal.dump(QC.default_conn_adapter.connection.object_id, write)
+      Marshal.dump(QC.default_queue.conn_adapter.connection.object_id, write)
     end
 
     write.close
@@ -261,11 +261,11 @@ class WorkerTest < QCTest
     QC.enqueue("TestObject.no_args")
     worker = TestWorker.new fork_worker: true
     read, write = IO.pipe
-    object_id = QC.default_conn_adapter.connection.object_id
+    object_id = QC.default_queue.conn_adapter.connection.object_id
     assert_equal(1, QC.count)
     output = worker.work do
       read.close
-      Marshal.dump(QC.default_conn_adapter.connection.object_id, write)
+      Marshal.dump(QC.default_queue.conn_adapter.connection.object_id, write)
     end
 
     write.close
@@ -281,10 +281,10 @@ class WorkerTest < QCTest
     QC.enqueue("QC.default_conn_adapter.execute", "SELECT 123 as value")
     worker = TestWorker.new fork_worker: true, asynchronous: true
     read, write = IO.pipe
-    object_id = QC.default_conn_adapter.connection.object_id
+    object_id = QC.default_queue.conn_adapter.connection.object_id
     fork_pid = worker.work do
       read.close
-      Marshal.dump(QC.default_conn_adapter.connection.object_id, write)
+      Marshal.dump(QC.default_queue.conn_adapter.connection.object_id, write)
     end
     assert_equal(1, QC.count) # not yet executed
     assert_equal(0, worker.failed_count)

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -279,7 +279,6 @@ class WorkerTest < QCTest
 
   def test_async_forked_work_that_does_sql
     QC.enqueue("QC.default_conn_adapter.execute", "SELECT 123 as value")
-    count = QC.default_conn_adapter.execute("SELECT count(*) from pg_stat_activity where datname = current_database()")["count"].to_i;
     worker = TestWorker.new fork_worker: true, asynchronous: true
     read, write = IO.pipe
     object_id = QC.default_conn_adapter.connection.object_id
@@ -292,8 +291,6 @@ class WorkerTest < QCTest
     write.close
     marshalled = read.read
     Process.wait(fork_pid)
-    new_count = QC.default_conn_adapter.execute("SELECT count(*) from pg_stat_activity where datname = current_database()")["count"].to_i;
-    assert(new_count == count, "should not leave any connections unclosed")
     new_object_id = Marshal.load(marshalled)
     assert(new_object_id != object_id, "should establish new connection")
     assert_equal(0, QC.count)


### PR DESCRIPTION
This is a follow up PR to #218. Sorry that it has got merged, but I don't see a better way to do without access to repo (which I don't really need).
- It adds :asynchronous option to workers that lets them finish their stuff in background.
- It adds work {} block, that will be executed in forked context, recieves worker output as argument
- It allows forked workers to use sql, but they are forced to reconnect in that case
- Async worker's work() returns pid that you can wait on, but it's not necessary.

It may be not rock solid, but I wrote specs and they pass. 
