### PR TITLE
remove useless require of thread

### DIFF
--- a/lib/queue_classic/conn_adapter.rb
+++ b/lib/queue_classic/conn_adapter.rb
@@ -1,4 +1,3 @@
-require 'thread'
 require 'uri'
 require 'pg'
 


### PR DESCRIPTION
This doesn't seem to be used in any ways here and all tests are still passing.

Did I miss anything?
