### PR TITLE
move unlock_jobs_of_dead_workers

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -91,11 +91,17 @@ module QC
     puts(out) if ENV["DEBUG"]
     return result
   end
-  
+
   def self.measure(data)
     if ENV['QC_MEASURE']
       $stdout.puts("measure#qc.#{data}")
     end
+  end
+
+  # This will unlock all jobs any postgres' PID that is not existing anymore
+  # to prevent any infinitely locked jobs
+  def self.unlock_jobs_of_dead_workers
+    @conn_adapter.execute("UPDATE #{QC::TABLE_NAME} SET locked_at = NULL, locked_by = NULL WHERE locked_by NOT IN (SELECT pid FROM pg_stat_activity);")
   end
 end
 

--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -39,7 +39,8 @@ module QC
     # The canonical example of starting a worker is as follows:
     # QC::Worker.new.start
     def start
-      unlock_jobs_of_dead_workers()
+      QC.unlock_jobs_of_dead_workers
+
       while @running
         @fork_worker ? fork_and_work : work
       end
@@ -93,12 +94,6 @@ module QC
         end
         @conn_adapter.wait(@wait_interval, *@queues.map {|q| q.name})
       end
-    end
-
-    # This will unlock all jobs any postgres' PID that is not existing anymore
-    # to prevent any infinitely locked jobs
-    def unlock_jobs_of_dead_workers
-      @conn_adapter.execute("UPDATE #{QC::TABLE_NAME} SET locked_at = NULL, locked_by = NULL WHERE locked_by NOT IN (SELECT pid FROM pg_stat_activity);")
     end
 
     # A job is processed by evaluating the target code.

--- a/test/lib/queue_classic_test.rb
+++ b/test/lib/queue_classic_test.rb
@@ -10,4 +10,23 @@ class QueueClassicTest < QCTest
     QC.default_conn_adapter = connection
     assert_equal(QC.default_conn_adapter, connection)
   end
+
+  def test_unlock_jobs_of_dead_workers
+    # Insert a locked job
+    adapter = QC::ConnAdapter.new
+    query = "INSERT INTO #{QC::TABLE_NAME} (q_name, method, args, locked_by, locked_at) VALUES ('whatever', 'Kernel.puts', '[\"ok?\"]', 0, (CURRENT_TIMESTAMP))"
+    adapter.execute(query)
+
+    # We should have no unlocked jobs
+    query_locked_jobs = "SELECT * FROM #{QC::TABLE_NAME} WHERE locked_at IS NULL"
+    res = adapter.connection.exec(query_locked_jobs)
+    assert_equal(0, res.count)
+
+    # Unlock the job
+    QC.unlock_jobs_of_dead_workers
+
+    # We should have an unlocked job now
+    res = adapter.connection.exec(query_locked_jobs)
+    assert_equal(1, res.count)
+  end
 end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -174,24 +174,4 @@ class WorkerTest < QCTest
     assert_equal(42, r)
     assert_equal(0, worker.failed_count)
   end
-
-  def test_unlock_jobs_of_dead_workers
-    # Insert a locked job
-    adapter = QC::ConnAdapter.new
-    query = "INSERT INTO #{QC::TABLE_NAME} (q_name, method, args, locked_by, locked_at) VALUES ('whatever', 'Kernel.puts', '[\"ok?\"]', 0, (CURRENT_TIMESTAMP))"
-    adapter.execute(query)
-
-    # We should have no unlocked jobs
-    query_locked_jobs = "SELECT * FROM #{QC::TABLE_NAME} WHERE locked_at IS NULL"
-    res = adapter.connection.exec(query_locked_jobs)
-    assert_equal(0, res.count)
-
-    # Unlock the job
-    QC::Worker.new.unlock_jobs_of_dead_workers
-
-    # We should have an unlocked job now
-    res = adapter.connection.exec(query_locked_jobs)
-    assert_equal(1, res.count)
-  end
-
 end


### PR DESCRIPTION
Reasons for this are:
- it has nothing to do with the QC::Worker class
- we want to be able to call that in other circumstances than from the Worker class

/cc @ukd1 @smathieu @ryandotsmith 
