### PR TITLE
make it possible to inject a custom worker for QC's rake tasks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ loop do
 end
 ```
 
+The `qc:work` rake task uses `QC::Worker` by default. However, it's easy to
+inject your own wrker class:
+
+```ruby
+QC.default_worker_class = MyWorker
+```
+
 ## Setup
 
 In addition to installing the rubygem, you will need to prepare your database. Database preparation includes creating a table and loading PL/pgSQL functions. You can issue the database preparation commands using `PSQL(1)` or use a database migration script.

--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -70,6 +70,7 @@ module QC
     @conn_adapter = conn
   end
 
+  # The worker class instantiated by QC's rake tasks.
   def self.default_worker_class
     @worker_class ||= QC::Worker
   end

--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -70,6 +70,14 @@ module QC
     @conn_adapter = conn
   end
 
+  def self.default_worker_class
+    @worker_class ||= QC::Worker
+  end
+
+  def self.default_worker_class=(worker_class)
+    @worker_class = worker_class
+  end
+
   def self.log_yield(data)
     begin
       t0 = Time.now

--- a/lib/queue_classic/tasks.rb
+++ b/lib/queue_classic/tasks.rb
@@ -8,7 +8,7 @@ end
 namespace :qc do
   desc "Start a new worker for the (default or $QUEUE) queue"
   task :work  => :environment do
-    @worker = QC::Worker.new
+    @worker = QC.default_worker_class.new
 
     trap('INT') do
       $stderr.puts("Received INT. Shutting down.")

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -27,6 +27,18 @@ class TestWorker < QC::Worker
 end
 
 class WorkerTest < QCTest
+  def test_qc_worker_is_the_default_worker
+    assert_equal QC::Worker, QC.default_worker_class
+  end
+
+  def test_default_worker_can_be_changed
+    original_worker = QC.default_worker_class
+    QC.default_worker_class = TestWorker
+
+    assert_equal TestWorker, QC.default_worker_class
+  ensure
+    QC.default_worker_class = original_worker
+  end
 
   def test_work
     QC.enqueue("TestObject.no_args")


### PR DESCRIPTION
In every project I'm using QueueClassic we end up writing
our own Worker. This is also encouraged in the README.

The process is very smooth but one drawback is that you can't
continue to use the rake tasks, which ship with QC. Or at least
not `rake qc:work` as this would always use the default worker.

I think we should encourage custom workers and make it trivial
to inject them into QC's rake tasks.

#### ToDo

- [x] rDoc
- [x] document Worker injection