### PR TITLE
Make QC a bit thread safe

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -49,17 +49,19 @@ Please use the method QC.#{config_method} instead.
   end
 
   def self.default_conn_adapter
-    return @conn_adapter if defined?(@conn_adapter) && @conn_adapter
-    if rails_connection_sharing_enabled?
-      @conn_adapter = ConnAdapter.new(ActiveRecord::Base.connection.raw_connection)
+    t = Thread.current
+    return t[:qc_conn_adapter] if t[:qc_conn_adapter]
+    adapter = if rails_connection_sharing_enabled?
+      ConnAdapter.new(ActiveRecord::Base.connection.raw_connection)
     else
-      @conn_adapter = ConnAdapter.new
+      ConnAdapter.new
     end
-    @conn_adapter
+
+    t[:qc_conn_adapter] = adapter
   end
 
   def self.default_conn_adapter=(conn)
-    @conn_adapter = conn
+    Thread.current[:qc_conn_adapter] = conn
   end
 
   def self.log_yield(data)


### PR DESCRIPTION
Related to #247.

Use thread local storage to save the configuration of the connection. This *DOES NOT* make QC fully thread safe. For instance, the default queue is stored globally. It's however unlikely that someone is using a different default queue per thread.