### PR TITLE
Change QC::Queue interface to support setting the conn adapter in the constructor.

### DIFF
--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -7,9 +7,10 @@ module QC
   class Queue
 
     attr_reader :name, :top_bound
-    def initialize(name, top_bound=nil)
+    def initialize(name, options = {})
       @name = name
-      @top_bound = top_bound || QC.top_bound
+      @adapter = options[:conn_adapter]
+      @top_bound = options.fetch(:top_bound) { QC.top_bound }
     end
 
     def conn_adapter=(a)

--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -156,7 +156,7 @@ module QC
     def setup_queues(adapter, queue, queues, top_bound)
       names = queues.length > 0 ? queues : [queue]
       names.map do |name|
-        QC::Queue.new(name, top_bound).tap do |q|
+        QC::Queue.new(name, top_bound: top_bound).tap do |q|
           q.conn_adapter = adapter
         end
       end

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -12,6 +12,12 @@ class QueueTest < QCTest
     assert_equal(true, QC.respond_to?(:enqueue))
   end
 
+  def test_connection_adapter_in_constructor
+    adapter = QC::ConnAdapter.new
+    queue = QC::Queue.new("test", conn_adapter: adapter)
+    assert_equal queue.conn_adapter, adapter
+  end
+
   def test_lock
     queue = QC::Queue.new("queue_classic_jobs")
     queue.enqueue("Klass.method")


### PR DESCRIPTION
Fixes #249
