### PR TITLE
Give some <3 to our unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: ruby
 before_script:
   - psql -c 'create database queue_classic_test;' -U postgres
 env:
-  - QC_DATABASE_URL="postgres://postgres@localhost/queue_classic_test"
-  - QC_BENCHMARK=true
+  global:
+    - QC_DATABASE_URL="postgres://postgres@localhost/queue_classic_test"
+    - QC_BENCHMARK=true
+    - QC_BENCHMARK_MAX_TIME_DEQUEUE=60
 rvm:
   - 2.2
   - 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ before_script:
   - psql -c 'create database queue_classic_test;' -U postgres
 env:
   - QC_DATABASE_URL="postgres://postgres@localhost/queue_classic_test"
+  - QC_BENCHMARK=true
 rvm:
   - 2.2
   - 2.1

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,5 @@ gem "rake"
 gemspec
 
 group :test do
-  gem "turn"
-  gem 'minitest', '~> 5.3.1'
+  gem 'minitest', '~> 5.5.1'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -11,5 +11,4 @@ Rake::TestTask.new do |t|
   t.test_files = FileList['test/**/*_test.rb']
   t.verbose = true
   t.warning = true
-  t.ruby_opts << "-rubygems" if RUBY_VERSION < "1.9"
 end

--- a/test/benchmark_test.rb
+++ b/test/benchmark_test.rb
@@ -2,36 +2,37 @@ require File.expand_path("../helper.rb", __FILE__)
 
 if ENV["QC_BENCHMARK"]
   class BenchmarkTest < QCTest
+    BENCHMARK_SIZE = Integer(ENV.fetch("QC_BENCHMARK_SIZE", 10_000))
+    BENCHMARK_MAX_TIME_DEQUEUE = Integer(ENV.fetch("QC_BENCHMARK_MAX_TIME_DEQUEUE", 30))
+    BENCHMARK_MAX_TIME_ENQUEUE = Integer(ENV.fetch("QC_BENCHMARK_MAX_TIME_ENQUEUE", 5))
 
     def test_enqueue
-      n = 10_000
       start = Time.now
-      n.times do
-        QC.enqueue("1.odd?", [])
+      BENCHMARK_SIZE.times do
+        QC.enqueue("1.odd?")
       end
-      assert_equal(n, QC.count)
+      assert_equal(BENCHMARK_SIZE, QC.count)
 
       elapsed = Time.now - start
-      assert_in_delta(4, elapsed, 1)
+      assert_operator(elapsed, :<, BENCHMARK_MAX_TIME_ENQUEUE)
     end
 
     def test_dequeue
       worker = QC::Worker.new
       worker.running = true
-      n = 10_000
-      n.times do
-        QC.enqueue("1.odd?", [])
+      BENCHMARK_SIZE.times do
+        QC.enqueue("1.odd?")
       end
-      assert_equal(n, QC.count)
+      assert_equal(BENCHMARK_SIZE, QC.count)
 
       start = Time.now
-      n.times do
+      BENCHMARK_SIZE.times do
         worker.work
       end
       elapsed = Time.now - start
 
       assert_equal(0, QC.count)
-      assert_in_delta(10, elapsed, 3)
+      assert_operator(elapsed, :<, BENCHMARK_MAX_TIME_DEQUEUE)
     end
 
   end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -118,16 +118,4 @@ class ConfigTest < QCTest
   ensure
     QC.default_worker_class = original_worker
   end
-
-  private
-  def with_env(temporary_environment)
-    original_environment = {}
-    temporary_environment.each do |name, value|
-      original_environment[name] = ENV[name]
-      ENV[name] = value
-    end
-    yield
-  ensure
-    original_environment.each { |name, value| ENV[name] = value }
-  end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -51,4 +51,14 @@ class QCTest < Minitest::Test
     $stdout = original_stdout
   end
 
+  def with_env(temporary_environment)
+    original_environment = {}
+    temporary_environment.each do |name, value|
+      original_environment[name] = ENV[name]
+      ENV[name] = value
+    end
+    yield
+  ensure
+    original_environment.each { |name, value| ENV[name] = value }
+  end
 end

--- a/test/lib/queue_classic_rails_connection_test.rb
+++ b/test/lib/queue_classic_rails_connection_test.rb
@@ -22,10 +22,10 @@ class QueueClassicRailsConnectionTest < QCTest
   end
 
   def test_does_not_use_active_record_connection_if_env_var_set
-    ENV['QC_RAILS_DATABASE'] = 'false'
-    connection = get_connection
-    assert_raises(MockExpectationError) { connection.verify }
-    ENV['QC_RAILS_DATABASE'] = 'true'
+    with_env 'QC_RAILS_DATABASE' => 'false' do
+      connection = get_connection
+      assert_raises(MockExpectationError) { connection.verify }
+    end
   end
 
   private


### PR DESCRIPTION
- Removed 'turn' gem which did not work anyway
- Updated minitest
- Fix Benchmark test
- Enable benchmark test in travis to avoid performance regressions
- Make benchmark test configurable to handle problems with different environment
- Use the with_env helper in Rails connection test to avoid env leak