### PR TITLE
Change json datatype to jsonb

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,9 +239,10 @@ All configuration takes place in the form of environment vars. See [queue_classi
 
 ## JSON
 
-If you are running PostgreSQL 9.2 or higher, queue_classic will use the [json](http://www.postgresql.org/docs/9.2/static/datatype-json.html) datatype for storing arguments. Versions 9.1 and lower will use the 'text' column. If you have installed queue_classic prior to version 2.1.4 and are running PostgreSQL >= 9.2, run the following to switch to using the json type:
+If you are running PostgreSQL 9.4 or higher, queue_classic will use the [jsonb](http://www.postgresql.org/docs/9.4/static/datatype-json.html) datatype for new tables. Versions 9.2 and 9.3 will use the `json` data type and versions 9.1 and lower will use the `text` data type.
+If you are updating queue_classic and are running PostgreSQL >= 9.4, run the following to switch to `jsonb`:
 ```
-alter table queue_classic_jobs alter column args type json using (args::json);
+alter table queue_classic_jobs alter column args type jsonb using (args::jsonb);
 ```
 
 ## Logging

--- a/changelog
+++ b/changelog
@@ -1,5 +1,6 @@
 Unreleased
 - Fixed a bug in the offset calculation of `.enqueue_at`.
+- Use the jsonb type for the args column from now on. If not available, fall back to json or text.
 
 Version 3.0.0rc
 - Improved signal handling

--- a/sql/create_table.sql
+++ b/sql/create_table.sql
@@ -11,10 +11,12 @@ CREATE TABLE queue_classic_jobs (
   scheduled_at timestamptz default now()
 );
 
--- If json type is available, use it for the args column.
-perform * from pg_type where typname = 'json';
-if found then
-  alter table queue_classic_jobs alter column args type json using (args::json);
+-- If jsonb type is available, use it for the args column
+if exists (select 1 from pg_type where typname = 'jsonb') then
+  alter table queue_classic_jobs alter column args type jsonb using args::jsonb;
+-- Otherwise, use json type for the args column if available
+elsif exists (select 1 from pg_type where typname = 'json') then
+  alter table queue_classic_jobs alter column args type json using args::json;
 end if;
 
 end $$ language plpgsql;


### PR DESCRIPTION
Hi,

as the json datatype needs to be parsed over and over again and queue_classic does not make assumptions about the ordering of args' keys, a switch to jsonb seems reasonable to me.

Quote from the PostgreSQL docs: *In general, most applications should prefer to store JSON data as jsonb, unless there are quite specialized needs, such as legacy assumptions about ordering of object keys.*
http://www.postgresql.org/docs/current/static/datatype-json.html

In case somebody uses 9.3 or earlier, I think it is OK to fall back to text and not check for both jsonb and json. With text we have at least no DB performance penalty, but json is reparsed with every insert. jsonb is parsed only once.