### PR TITLE
Fix for postgres versions below 9.2

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 Unreleased
 - Fixed a bug in the offset calculation of `.enqueue_at`.
 - Use the jsonb type for the args column from now on. If not available, fall back to json or text.
+- Fixed unlock query for versions below Postgres 9.2
 
 Version 3.0.0rc
 - Improved signal handling

--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -100,7 +100,10 @@ Please use the method QC.#{config_method} instead.
   # This will unlock all jobs any postgres' PID that is not existing anymore
   # to prevent any infinitely locked jobs
   def self.unlock_jobs_of_dead_workers
-    default_conn_adapter.execute("UPDATE #{QC.table_name} SET locked_at = NULL, locked_by = NULL WHERE locked_by NOT IN (SELECT pid FROM pg_stat_activity);")
+    server_version_num = default_conn_adapter.execute("SHOW server_version_num;")["server_version_num"]
+    pid_string = server_version_num && server_version_num.to_i < 90200 ? "procpid" : "pid"
+
+    default_conn_adapter.execute("UPDATE #{QC.table_name} SET locked_at = NULL, locked_by = NULL WHERE locked_by NOT IN (SELECT #{pid_string} FROM pg_stat_activity);")
   end
 
   # private class methods


### PR DESCRIPTION
In postgres 9.2, `procpid` was changed to `pid`.

Earlier versions should use `procpid`, this change fixes the issue
where this query would return an error in versions prior to postgres
9.2.