### PR TITLE
`enqueue`, `enqueue_at`, `enqueue_in` return job hash with id

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 Unreleased
 - Fixed a bug in the offset calculation of `.enqueue_at`.
 - Use the jsonb type for the args column from now on. If not available, fall back to json or text.
+- `enqueue`, `enqueue_at`, `enqueue_in` return job hash with id.
 
 Version 3.0.0rc
 - Improved signal handling

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -186,4 +186,23 @@ class QueueTest < QCTest
     assert_equal(1, msgs.length)
   end
 
+  def test_enqueue_returns_job_id
+    enqueued_job = QC.enqueue("Klass.method")
+    locked_job = QC.lock
+    assert_equal enqueued_job, "id" => locked_job[:id]
+  end
+
+  def test_enqueue_in_returns_job_id
+    enqueued_job = QC.enqueue_in(1, "Klass.method")
+    sleep 1
+    locked_job = QC.lock
+    assert_equal enqueued_job, "id" => locked_job[:id]
+  end
+
+  def test_enqueue_at_returns_job_id
+    enqueued_job = QC.enqueue_at(Time.now + 1, "Klass.method")
+    sleep 1
+    locked_job = QC.lock
+    assert_equal enqueued_job, "id" => locked_job[:id]
+  end
 end


### PR DESCRIPTION
Closes #260

Rails issue about `provider_job_id`: https://github.com/rails/rails/issues/18821

This will make it possible to provide a better integration with Active
Job by providing a mean to implement `active_job.provider_job_id`.