### PR TITLE
Rescue ScriptError and NoMemoryError as well as StandardError.

### DIFF
--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -102,7 +102,7 @@ module QC
     # then it is deleted from the queue.
     # If the job has raised an exception the responsibility of what
     # to do with the job is delegated to Worker#handle_failure.
-    # If the job is not finished and an INT signal is traped,
+    # If the job is not finished and an INT signal is trapped,
     # this method will unlock the job in the queue.
     def process(queue, job)
       start = Time.now
@@ -112,7 +112,10 @@ module QC
           queue.delete(job[:id])
           finished = true
         end
-      rescue => e
+      rescue StandardError, ScriptError, NoMemoryError => e
+        # We really only want to unlock the job for signal and system exit
+        # exceptions. If we encounter a ScriptError or a NoMemoryError any
+        # future run will likely encounter the same error.
         handle_failure(job, e)
         finished = true
       ensure
@@ -134,8 +137,8 @@ module QC
       receiver.send(message, *args)
     end
 
-    # This method will be called when an exception
-    # is raised during the execution of the job.
+    # This method will be called when a StandardError, ScriptError or
+    # NoMemoryError is raised during the execution of the job.
     def handle_failure(job,e)
       $stderr.puts("count#qc.job-error=1 job=#{job} error=#{e.inspect} at=#{e.backtrace.first}")
     end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -201,6 +201,130 @@ class WorkerTest < QCTest
     end
   end
 
+  def test_worker_unlocks_job_on_signal_exception
+    job_details = QC.enqueue("Kernel.eval", "raise SignalException.new('INT')")
+    worker = TestWorker.new
+
+    unlocked = nil
+
+    fake_unlock = Proc.new do |job_id|
+      if job_id == job_details['id']
+        unlocked = true
+      end
+      original_unlock(job_id)
+    end
+
+    stub_any_instance(QC::Queue, :unlock, fake_unlock) do
+      begin
+        worker.work
+      rescue SignalException
+      ensure
+        assert unlocked, "SignalException failed to unlock the job in the queue."
+      end
+    end
+  end
+
+  def test_worker_unlocks_job_on_system_exit
+    job_details = QC.enqueue("Kernel.eval", "raise SystemExit.new")
+    worker = TestWorker.new
+
+    unlocked = nil
+
+    fake_unlock = Proc.new do |job_id|
+      if job_id == job_details['id']
+        unlocked = true
+      end
+      original_unlock(job_id)
+    end
+
+    stub_any_instance(QC::Queue, :unlock, fake_unlock) do
+      begin
+        worker.work
+      rescue SystemExit
+      ensure
+        assert unlocked, "SystemExit failed to unlock the job in the queue."
+      end
+    end
+  end
+
+  def test_worker_does_not_unlock_jobs_on_syntax_error
+    job_details = QC.enqueue("Kernel.eval", "bad syntax")
+    worker = TestWorker.new
+
+    unlocked = nil
+
+    fake_unlock = Proc.new do |job_id|
+      if job_id == job_details['id']
+        unlocked = true
+      end
+      original_unlock(job_id)
+    end
+
+    stub_any_instance(QC::Queue, :unlock, fake_unlock) do
+      begin
+        errors = capture_stderr_output do
+          worker.work
+        end
+      ensure
+        message = "SyntaxError unexpectedly unlocked the job in the queue."
+        message << "\nErrors:\n#{errors}" unless errors.empty?
+        refute unlocked, message
+      end
+    end
+  end
+
+  def test_worker_does_not_unlock_jobs_on_load_error
+    job_details = QC.enqueue("Kernel.eval", "require 'not_a_real_file'")
+    worker = TestWorker.new
+
+    unlocked = nil
+
+    fake_unlock = Proc.new do |job_id|
+      if job_id == job_details['id']
+        unlocked = true
+      end
+      original_unlock(job_id)
+    end
+
+    stub_any_instance(QC::Queue, :unlock, fake_unlock) do
+      begin
+        errors = capture_stderr_output do
+          worker.work
+        end
+      ensure
+        message = "LoadError unexpectedly unlocked the job in the queue."
+        message << "\nErrors:\n#{errors}" unless errors.empty?
+        refute unlocked, message
+      end
+    end
+  end
+
+  def test_worker_does_not_unlock_jobs_on_no_memory_error
+    job_details = QC.enqueue("Kernel.eval", "raise NoMemoryError.new")
+    worker = TestWorker.new
+
+    unlocked = nil
+
+    fake_unlock = Proc.new do |job_id|
+      if job_id == job_details['id']
+        unlocked = true
+      end
+      original_unlock(job_id)
+    end
+
+    stub_any_instance(QC::Queue, :unlock, fake_unlock) do
+      begin
+        errors = capture_stderr_output do
+          worker.work
+        end
+      ensure
+        message = "NoMemoryError unexpectedly unlocked the job in the queue."
+        message << "\nErrors:\n#{errors}" unless errors.empty?
+        refute unlocked, message
+      end
+    end
+  end
+
   private
 
   def with_database(url)


### PR DESCRIPTION
If a job raises a ScriptError or NoMemoryError it is unlikely to be successful
if retried. Rather than unlocking the job just mark it as finished and call
handle_error.

This recently bit us when workers were queued up to read a file that was deleted out from under them. Because the rescue block here wasn't catching the LoadError the job wouldn't be marked as finished and it would be unlocked for the next hapless worker to come along.

We're now rescuing these errors ourselves but I can't really think of a case where someone would want to unlock and retry a job that raised one of these errors so I thought it might be useful upstream.

Does this approach seem reasonable? I'm happy to come at it another way if you have suggestions.
