### PR TITLE
Don't rescue Time.now exceptions in log_yield

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -65,8 +65,8 @@ Please use the method QC.#{config_method} instead.
   end
 
   def self.log_yield(data)
+    t0 = Time.now
     begin
-      t0 = Time.now
       yield
     rescue => e
       log({:at => "error", :error => e.inspect}.merge(data))


### PR DESCRIPTION
Fixes QueueClassic/queue_classic#268