### PR TITLE
Use correct gem version specification in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ $ ruby -r queue_classic -e "QC::Worker.new.work"
 Declare dependencies in Gemfile.
 ```ruby
 source "http://rubygems.org"
-gem "queue_classic", "~> 3.0.0"
+gem "queue_classic", "~> 3.1.0"
 ```
 
 Add the database tables and stored procedures.


### PR DESCRIPTION
README on 3.1.x branch currently shows how to install 3.0.x.