### PR TITLE
Fix custom worker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ trap('INT') { exit }
 trap('TERM') { worker.stop }
 
 loop do
-  job = worker.lock_job
-  Timeout::timeout(5) { worker.process(job) }
+  queue, job = worker.lock_job
+  Timeout::timeout(5) { worker.process(queue, job) }
 end
 ```
 


### PR DESCRIPTION
[`Worker#lock_job`] (https://github.com/YodelTalk/queue_classic/blob/master/lib/queue_classic/worker.rb#L92-L94) returns two parameters! This commit fixes the example code which give me a little headache wondering why my custom worker did not work. 😉  