### PR TITLE
Bump pg version dependency

### DIFF
--- a/queue_classic.gemspec
+++ b/queue_classic.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = %w[lib]
 
-  spec.add_dependency "pg", ">= 0.17", "< 0.19"
+  spec.add_dependency "pg", ">= 0.17", "< 0.20"
 end


### PR DESCRIPTION
Update pg version dependency to no longer block the current pg stable version 0.19 and future 0.19.x versions.