### PR TITLE
[refactor] tasks: use Kernel#abort

### DIFF
--- a/lib/queue_classic/tasks.rb
+++ b/lib/queue_classic/tasks.rb
@@ -11,11 +11,8 @@ namespace :qc do
     @worker = QC.default_worker_class.new
 
     trap('INT') do
-      $stderr.puts("Received INT. Shutting down.")
-      if !@worker.running
-        $stderr.puts("Worker has stopped running. Exit.")
-        exit(1)
-      end
+      $stderr.puts("Received INT. Shutting down.")      
+      abort("Worker has stopped running. Exit.") unless @worker.running
       @worker.stop
     end
 


### PR DESCRIPTION
This PR makes a very small local change to the TRAP INT handler.

  - the exit code is now platform-appropriate instead of 1 - that is, 1, on most platforms
  - save a single line of code

