### PR TITLE
Automatically retry enqueuing after connection reset

### DIFF
--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -112,6 +112,50 @@ class QueueTest < QCTest
     queue.conn_adapter.disconnect
   end
 
+  def test_enqueue_retry
+    queue = QC::Queue.new("queue_classic_jobs")
+    queue.conn_adapter = QC::ConnAdapter.new
+    conn = queue.conn_adapter.connection
+    conn.exec('select pg_terminate_backend(pg_backend_pid())') rescue nil
+    queue.enqueue("Klass.method")
+    assert_equal(1, queue.count)
+    queue.conn_adapter.disconnect
+  end
+
+  def test_enqueue_stops_retrying_on_permanent_error
+    queue = QC::Queue.new("queue_classic_jobs")
+    queue.conn_adapter = QC::ConnAdapter.new
+    conn = queue.conn_adapter.connection
+    conn.exec('select pg_terminate_backend(pg_backend_pid())') rescue nil
+    # Simulate permanent connection error
+    def conn.exec(*args); raise(PGError); end
+    # Ensure that the error is reraised on second time
+    assert_raises(PG::Error) {queue.enqueue("Klass.other_method")}
+    queue.conn_adapter.disconnect
+  end
+
+  def test_enqueue_in_retry
+    queue = QC::Queue.new("queue_classic_jobs")
+    queue.conn_adapter = QC::ConnAdapter.new
+    conn = queue.conn_adapter.connection
+    conn.exec('select pg_terminate_backend(pg_backend_pid())') rescue nil
+    queue.enqueue_in(10,"Klass.method")
+    assert_equal(1, queue.count)
+    queue.conn_adapter.disconnect
+  end
+
+  def test_enqueue_in_stops_retrying_on_permanent_error
+    queue = QC::Queue.new("queue_classic_jobs")
+    queue.conn_adapter = QC::ConnAdapter.new
+    conn = queue.conn_adapter.connection
+    conn.exec('select pg_terminate_backend(pg_backend_pid())') rescue nil
+    # Simulate permanent connection error
+    def conn.exec(*args); raise(PGError); end
+    # Ensure that the error is reraised on second time
+    assert_raises(PG::Error) {queue.enqueue_in(10,"Klass.method")}
+    queue.conn_adapter.disconnect
+  end
+
   def test_custom_default_queue
     queue_class = Class.new do
       attr_accessor :jobs


### PR DESCRIPTION
If DB connection is dropped for any reason, QC does `reset` the connection but does not retry enqueuing the job.

This PR adds retry-once logic to `enqueue` and `enqueue_in` (and through that to `enqueue_at`) so that when the initial `execute` fails with `PGError`, it is retried once (after execute's rescue has reset the connection).

**Rationale**: QC should give it's best to ensure the `enqueue` results in a enqueued job in DB, so if the DB connection has gone bad, resetting it is not enough and we should repeat the `INSERT` also. Leaving the retry logic to the app code is sub-optimal as then everybody need to implement the same code.
I added the retry only to `enqueue` and `enqueue_in`, not to `execute`, so that other SQL statements can be executed without automatically retrying on PGError.