### PR TITLE
check that the connection is still able to make queries

### DIFF
--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -50,7 +50,8 @@ Please use the method QC.#{config_method} instead.
 
   def self.default_conn_adapter
     t = Thread.current
-    return t[:qc_conn_adapter] if t[:qc_conn_adapter]
+    return t[:qc_conn_adapter] if t[:qc_conn_adapter] && t[:qc_conn_adapter].active?
+
     adapter = if rails_connection_sharing_enabled?
       ConnAdapter.new(ActiveRecord::Base.connection.raw_connection)
     else

--- a/lib/queue_classic/conn_adapter.rb
+++ b/lib/queue_classic/conn_adapter.rb
@@ -55,6 +55,11 @@ module QC
                           end
     end
 
+    def active?
+      !@connection.finished? &&
+        @connection.transaction_status < PG::Connection::PQTRANS_INERROR
+    end
+
     private
 
     def wait_for_notify(t)

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -17,6 +17,7 @@ module QC
     end
 
     def conn_adapter
+      @adapter = nil if defined?(@adapter) && !@adapter.active?
       @adapter ||= QC.default_conn_adapter
     end
 


### PR DESCRIPTION
Before making requests against the `QC::Queue::conn_adapter`, check that we are not in an errored state.

We can do this by checking that the connection has not finished, and also checking that we are not in an error/unknown state.

If the connection is no longer active, wipe and refresh the memoized version.