### PR TITLE
Remove support for older Postgres versions, also add migrations for 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,14 +258,6 @@ $ bundle exec rake qc:update
 
 All configuration takes place in the form of environment vars. See [queue_classic.rb](https://github.com/QueueClassic/queue_classic/blob/master/lib/queue_classic.rb#L23-62) for a list of options.
 
-## JSON
-
-Queue Classic will use the [jsonb](https://www.postgresql.org/docs/9.6/datatype-json.html) datatype for new tables. If you are updating queue_classic, and are running PostgreSQL >= 9.6, run the following to switch to `jsonb`:
-
-```sql
-alter table queue_classic_jobs alter column args type jsonb using (args::jsonb);
-```
-
 ## Logging
 
 By default queue_classic does not talk very much.

--- a/lib/generators/queue_classic/install_generator.rb
+++ b/lib/generators/queue_classic/install_generator.rb
@@ -33,6 +33,10 @@ module QC
       if self.class.migration_exists?('db/migrate', 'update_queue_classic_3_1_0').nil?
         migration_template 'update_queue_classic_3_1_0.rb', 'db/migrate/update_queue_classic_3_1_0.rb'
       end
+
+      if self.class.migration_exists?('db/migrate', 'update_queue_classic_4_0_0').nil?
+        migration_template 'update_queue_classic_4_0_0.rb', 'db/migrate/update_queue_classic_4_0_0.rb'
+      end
     end
   end
 end

--- a/lib/generators/queue_classic/templates/update_queue_classic_4_0_0.rb
+++ b/lib/generators/queue_classic/templates/update_queue_classic_4_0_0.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UpdateQueueClassic400 < ActiveRecord::Migration[4.2]
+  def self.up
+    QC::Setup.update_to_4_0_0
+  end
+
+  def self.down
+    QC::Setup.downgrade_from_4_0_0
+  end
+end

--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -102,8 +102,7 @@ Please use the method QC.#{config_method} instead.
   # This will unlock all jobs any postgres' PID that is not existing anymore
   # to prevent any infinitely locked jobs
   def self.unlock_jobs_of_dead_workers
-    pid_column = default_conn_adapter.server_version < 90200 ? "procpid" : "pid"
-    default_conn_adapter.execute("UPDATE #{QC.table_name} SET locked_at = NULL, locked_by = NULL WHERE locked_by NOT IN (SELECT #{pid_column} FROM pg_stat_activity);")
+    default_conn_adapter.execute("UPDATE #{QC.table_name} SET locked_at = NULL, locked_by = NULL WHERE locked_by NOT IN (SELECT pid FROM pg_stat_activity);")
   end
 
   # private class methods

--- a/lib/queue_classic/setup.rb
+++ b/lib/queue_classic/setup.rb
@@ -10,6 +10,8 @@ module QC
     DowngradeFrom_3_0_0 = File.join(Root, "/sql/downgrade_from_3_0_0.sql")
     UpgradeTo_3_1_0 = File.join(Root, "/sql/update_to_3_1_0.sql")
     DowngradeFrom_3_1_0 = File.join(Root, "/sql/downgrade_from_3_1_0.sql")
+    UpgradeTo_4_0_0 = File.join(Root, "/sql/update_to_4_0_0.sql")
+    DowngradeFrom_4_0_0 = File.join(Root, "/sql/downgrade_from_4_0_0.sql")
 
     def self.create(c = QC::default_conn_adapter.connection)
       conn = QC::ConnAdapter.new(c)
@@ -29,6 +31,7 @@ module QC
       conn = QC::ConnAdapter.new(c)
       conn.execute(File.read(UpgradeTo_3_0_0))
       conn.execute(File.read(UpgradeTo_3_1_0))
+      conn.execute(File.read(UpgradeTo_4_0_0))
       conn.execute(File.read(DropSqlFunctions))
       conn.execute(File.read(SqlFunctions))
     end
@@ -55,6 +58,18 @@ module QC
     def self.downgrade_from_3_1_0(c = QC::default_conn_adapter.connection)
       conn = QC::ConnAdapter.new(c)
       conn.execute(File.read(DowngradeFrom_3_1_0))
+    end
+
+    def self.update_to_4_0_0(c = QC::default_conn_adapter.connection)
+      conn = QC::ConnAdapter.new(c)
+      conn.execute(File.read(UpgradeTo_4_0_0))
+      conn.execute(File.read(DropSqlFunctions))
+      conn.execute(File.read(SqlFunctions))
+    end
+
+    def self.downgrade_from_4_0_0(c = QC::default_conn_adapter.connection)
+      conn = QC::ConnAdapter.new(c)
+      conn.execute(File.read(DowngradeFrom_4_0_0))
     end
   end
 end

--- a/sql/create_table.sql
+++ b/sql/create_table.sql
@@ -4,20 +4,12 @@ CREATE TABLE queue_classic_jobs (
   id bigserial PRIMARY KEY,
   q_name text NOT NULL CHECK (length(q_name) > 0),
   method text NOT NULL CHECK (length(method) > 0),
-  args   text NOT NULL,
+  args   jsonb NOT NULL,
   locked_at timestamptz,
   locked_by integer,
   created_at timestamptz DEFAULT now(),
   scheduled_at timestamptz DEFAULT now()
 );
-
--- If jsonb type is available, use it for the args column
-IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'jsonb') THEN
-  ALTER TABLE queue_classic_jobs ALTER COLUMN args TYPE jsonb USING args::jsonb;
--- Otherwise, use json type for the args column if available
-ELSIF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'json') THEN
-  ALTER TABLE queue_classic_jobs ALTER COLUMN args TYPE json USING args::json;
-END IF;
 
 END $$ LANGUAGE plpgsql;
 

--- a/sql/downgrade_from_4_0_0.sql
+++ b/sql/downgrade_from_4_0_0.sql
@@ -1,0 +1,88 @@
+DO $$DECLARE r record;
+BEGIN
+  -- If jsonb type is available, do nothing as we're downgrading from 4.0.0
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'jsonb') THEN
+   -- do nothing - it should already be already jsonb
+  -- Otherwise, use json type for the args column if available
+  ELSIF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'json') THEN
+    -- this should only happen if someone downgrades QC and their database < pg 9.4
+    ALTER TABLE queue_classic_jobs ALTER COLUMN args TYPE json USING args::json;
+  END IF;
+
+
+END$$;
+
+
+--
+-- Re install the lock_head function
+--
+
+-- We are declaring the return type to be queue_classic_jobs.
+-- This is ok since I am assuming that all of the users added queues will
+-- have identical columns to queue_classic_jobs.
+-- When QC supports queues with columns other than the default, we will have to change this.
+
+CREATE OR REPLACE FUNCTION lock_head(q_name varchar, top_boundary integer)
+RETURNS SETOF queue_classic_jobs AS $$
+DECLARE
+  unlocked bigint;
+  relative_top integer;
+  job_count integer;
+BEGIN
+  -- The purpose is to release contention for the first spot in the table.
+  -- The select count(*) is going to slow down dequeue performance but allow
+  -- for more workers. Would love to see some optimization here...
+
+  EXECUTE 'SELECT count(*) FROM '
+    || '(SELECT * FROM queue_classic_jobs '
+    || ' WHERE locked_at IS NULL'
+    || ' AND q_name = '
+    || quote_literal(q_name)
+    || ' AND scheduled_at <= '
+    || quote_literal(now())
+    || ' LIMIT '
+    || quote_literal(top_boundary)
+    || ') limited'
+  INTO job_count;
+
+  SELECT TRUNC(random() * (top_boundary - 1))
+  INTO relative_top;
+
+  IF job_count < top_boundary THEN
+    relative_top = 0;
+  END IF;
+
+  LOOP
+    BEGIN
+      EXECUTE 'SELECT id FROM queue_classic_jobs '
+        || ' WHERE locked_at IS NULL'
+        || ' AND q_name = '
+        || quote_literal(q_name)
+        || ' AND scheduled_at <= '
+        || quote_literal(now())
+        || ' ORDER BY id ASC'
+        || ' LIMIT 1'
+        || ' OFFSET ' || quote_literal(relative_top)
+        || ' FOR UPDATE NOWAIT'
+      INTO unlocked;
+      EXIT;
+    EXCEPTION
+      WHEN lock_not_available THEN
+        -- do nothing. loop again and hope we get a lock
+    END;
+  END LOOP;
+
+  RETURN QUERY EXECUTE 'UPDATE queue_classic_jobs '
+    || ' SET locked_at = (CURRENT_TIMESTAMP),'
+    || ' locked_by = (select pg_backend_pid())'
+    || ' WHERE id = $1'
+    || ' AND locked_at is NULL'
+    || ' RETURNING *'
+  USING unlocked;
+
+  RETURN;
+END $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION lock_head(tname varchar) RETURNS SETOF queue_classic_jobs AS $$ BEGIN
+  RETURN QUERY EXECUTE 'SELECT * FROM lock_head($1,10)' USING tname;
+END $$ LANGUAGE plpgsql;

--- a/sql/update_to_4_0_0.sql
+++ b/sql/update_to_4_0_0.sql
@@ -1,0 +1,6 @@
+DO $$DECLARE r record;
+BEGIN
+  ALTER TABLE queue_classic_jobs ALTER COLUMN args TYPE jsonb USING args::jsonb;
+  DROP FUNCTION IF EXISTS lock_head(tname varchar);
+  DROP FUNCTION IF EXISTS lock_head(q_name varchar, top_boundary integer);
+END$$;


### PR DESCRIPTION
So, for 4.0, we don't actually need the migrations to run - it's backwards compatible at the moment. However, running them does clean up ``lock_head`` and make sure you're using ``jsonb`` on your ``args`` column. 

Rolling back will replace the ``lock_head`` function, and will downgrade you to ``json`` if you don't have support for ``jsonb`` (tbh, think it's pretty unlikely anyone will downgrade _postgres_ as well rollback a release of queue_classic, but 🤷‍♂)

cc @shosti @magni- 👋 

