### PR TITLE
Remove excess memoization of ConnAdapter instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## `master`
+
+Bug fixes:
+- [Fix excess memoization of `ConnAdapter` instances causing single global connection shared between threads and connections taken from ActiveRecord becoming shared between its pool and QC](https://github.com/QueueClassic/queue_classic/pull/318)
+
 ## [4.0.0-alpha1] - 2019-07-18
 
 Updates:

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -19,7 +19,7 @@ module QC
     end
 
     def conn_adapter
-      @adapter ||= QC.default_conn_adapter
+      @adapter || QC.default_conn_adapter
     end
 
     # enqueue(m,a) inserts a row into the jobs table and trigger a notification.

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -19,7 +19,7 @@ module QC
     end
 
     def conn_adapter
-      @adapter || QC.default_conn_adapter
+      (defined?(@adapter) && @adapter) || QC.default_conn_adapter
     end
 
     # enqueue(m,a) inserts a row into the jobs table and trigger a notification.

--- a/queue_classic.gemspec
+++ b/queue_classic.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w[lib]
 
   spec.add_dependency "pg", ">= 0.17", "< 2.0"
+  spec.add_development_dependency "activerecord", "~> 5.2.3"
 end

--- a/test/activerecord_integration_test.rb
+++ b/test/activerecord_integration_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'helper'
+require 'active_record'
+
+class QueueClassicActiverecordIntegrationTest < QCTest
+  def setup
+    super
+    reset_globals
+    ActiveRecord::Base.establish_connection "#{ENV["DATABASE_URL"]}?pool=1"
+  end
+
+  def teardown
+    super
+  end
+
+  def test_connection_not_returned_to_pool
+    take_connection_until_checked = Mutex.new
+    conn_adapter_ready = Queue.new
+    connection_from_adapter = nil
+    take_connection_until_checked.synchronize do
+      Thread.new do
+        with_env 'QC_RAILS_DATABASE' => 'true' do
+          conn_adapter_ready.push QC.default_conn_adapter.connection
+        end
+        take_connection_until_checked.synchronize {}
+        ActiveRecord::Base.clear_active_connections!
+      end
+
+      connection_from_adapter = conn_adapter_ready.pop
+
+      ActiveRecord::Base.connection_pool.reap
+
+      # Pool now has no free connections available
+      assert_raises(ActiveRecord::ConnectionTimeoutError) do
+        ActiveRecord::Base.connection_pool.checkout 0.1
+      end
+    end
+  end
+end

--- a/test/lib/queue_classic_rails_connection_test.rb
+++ b/test/lib/queue_classic_rails_connection_test.rb
@@ -91,8 +91,4 @@ class QueueClassicRailsConnectionTest < QCTest
     QC.default_conn_adapter
     connection
   end
-
-  def stub_activerecord_module
-
-  end
 end


### PR DESCRIPTION
- Removed memoization of `ConnAdapter` returned by `QC.default_conn_adapter` in `Queue`

   `QC.default_conn_adapter` already memoizes `ConnAdapter` instance if needed, so memoizing it again is unnecessary.

   This double memoization had problem: despite `default_conn_adapter` memoizing its connection adapter instance as _thread-local_ variable, there's global instance of `Queue` in `@default_queue`, and it memoizes `@conn_adapter` taken from `QC.default_conn_adapter`. So connection becomes _global_.

   https://github.com/QueueClassic/queue_classic/blob/4260d8963ddef91bdb9ae390d93e811521b83350/lib/queue_classic/config.rb#L30-L33

   For example, this singleton connection causes problems with ActiveRecord pool _reaper_ (https://github.com/QueueClassic/queue_classic/issues/317#issuecomment-520186299).

   If connection adapter (and its connection) was _really intended to be global_, and not per-thread, then I don't understand why `QC.default_conn_adapter` has thread-local memoization (8e208e2fe529da194a0dddc721f2e57f0d45ab9f).

   As `Queue` has setter `conn_adapter=`, for backwards compatibility, if connection is set via setter, it's then returned by `conn_adapter`. However, I don't understand necessity of this setter API, as overwriting connection adapter for existing queue instance is a recipe for mess. Maybe should be deprecated in future.

   **Potential problems with this change**: it breaks assumption that there's single global connection for all threads. But 8e208e2fe529da194a0dddc721f2e57f0d45ab9f suggests that it's not design assumption but a bug, and there should be one connection per thread. If an app starts lots of threads, uses QC in them and then kills them, it would be really bad as connections will remain open until GC, however isn't it by design? ConnAdapter has `disconnect` method.

- Removed memoization of `ActiveRecord::Base.connection` in `default_conn_adapter`

   Connection borrowed from ActiveRecord pool by calling `connection` shouldn't be stored anywhere as it will be likely returned back to pool with `ActiveRecord::Base.clear_active_connections!`, or with `reap` if thread that borrowed it is dead. Rails calls this method after handling each request. Again, ActiveRecord has its own memoization for connection assigned to current thread.

   This probably fixes #317 (common `PG::ConnectionBad: connection is closed` error).

   Memoization for non-activerecord connections remains, as connection managed by QC itself should have its owner. Also, there's setter too, and if ConnAdapter is set via setter, it's no longer taken from ActiveRecord.

   **Potential problems with this change**: when using ActiveRecord _without Rails_, you have to call `clear_active_connections!`, but at least now it's safe to call it.