### PR TITLE
 Use a CTE to prevent a nested loop from locking multiple jobs

### DIFF
--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -91,9 +91,20 @@ module QC
     def lock
       QC.log_yield(:measure => 'queue.lock') do
         s = <<~SQL
-          UPDATE queue_classic_jobs SET locked_at = now(), locked_by = pg_backend_pid()
-          WHERE id IN ( SELECT id FROM queue_classic_jobs WHERE locked_at IS NULL AND
-          q_name = $1 AND scheduled_at <= now() LIMIT 1 FOR NO KEY UPDATE SKIP LOCKED )
+          UPDATE queue_classic_jobs
+          SET
+            locked_at = now(),
+            locked_by = pg_backend_pid()
+          WHERE id IN (
+            SELECT id
+            FROM queue_classic_jobs
+            WHERE
+              locked_at IS NULL AND
+              q_name = $1 AND
+              scheduled_at <= now()
+            LIMIT 1
+            FOR NO KEY UPDATE SKIP LOCKED
+          )
           RETURNING *
         SQL
 

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -90,10 +90,12 @@ module QC
 
     def lock
       QC.log_yield(:measure => 'queue.lock') do
-        s = "UPDATE queue_classic_jobs SET locked_at = now(), locked_by = pg_backend_pid()
-             WHERE id IN ( SELECT id FROM queue_classic_jobs WHERE locked_at IS NULL AND
-             q_name = $1 AND scheduled_at <= now() LIMIT 1 FOR NO KEY UPDATE SKIP LOCKED )
-             RETURNING *"
+        s = <<~SQL
+          UPDATE queue_classic_jobs SET locked_at = now(), locked_by = pg_backend_pid()
+          WHERE id IN ( SELECT id FROM queue_classic_jobs WHERE locked_at IS NULL AND
+          q_name = $1 AND scheduled_at <= now() LIMIT 1 FOR NO KEY UPDATE SKIP LOCKED )
+          RETURNING *
+        SQL
 
         if r = conn_adapter.execute(s, name)
           {}.tap do |job|


### PR DESCRIPTION
We‘ve run into an intermittent issue when testing `4.0.0-alpha1` in that sometimes the queue lock query locks and returns more than one job row.

Some research suggested what is happening is the subquery is sometimes being inlined into a nested loop and invoked multiple times for each job row. As each evaluation locks the row, this results in the subquery locking and returning a different row each time. This reproduced intermittently in our application tests when run in a tight loop.

Moving the job selection part of this query into a CTE forces PostgreSQL to evaluate it once and solves the problem.

References:
* https://dba.stackexchange.com/a/199582
* https://dba.stackexchange.com/a/69497