### PR TITLE
fixes issue #314. Guard against timestamp coming back as Time class instance

### DIFF
--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -117,7 +117,7 @@ module QC
             job[:method] = r["method"]
             job[:args] = JSON.parse(r["args"])
             if r["scheduled_at"]
-              job[:scheduled_at] = Time.parse(r["scheduled_at"])
+              job[:scheduled_at] = r["scheduled_at"].kind_of?(Time) ? r["scheduled_at"] : Time.parse(r["scheduled_at"])
               ttl = Integer((Time.now - job[:scheduled_at]) * 1000)
               QC.measure("time-to-lock=#{ttl}ms source=#{name}")
             end

--- a/queue_classic.gemspec
+++ b/queue_classic.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w[lib]
 
   spec.add_dependency "pg", ">= 0.17", "< 2.0"
+  spec.add_development_dependency "activerecord", ">= 5.0.0", "< 6.1"
 end

--- a/test/lib/queue_classic_test_with_activerecord_typecast.rb
+++ b/test/lib/queue_classic_test_with_activerecord_typecast.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../helper.rb", __FILE__)
+
+class QueueClassicTest < QCTest
+  def before_teardown
+    ActiveRecord.send :remove_const, :Base
+    Object.send :remove_const, :ActiveRecord
+
+    QC.default_conn_adapter = @original_conn_adapter
+  end
+
+  def test_lock_with_active_record_timestamp_type_cast
+    # Insert an unlocked job
+    p_queue = QC::Queue.new("priority_queue")
+    conn_adapter = Minitest::Mock.new
+    conn_adapter.expect(:execute, {"id" => '1', "q_name" => 'test', "method" => "Kernel.puts", "args" => "[]", "scheduled_at" => Time.now}, [String, String])
+    QC.default_conn_adapter = conn_adapter
+    assert_equal(p_queue.lock, {})
+  end
+end


### PR DESCRIPTION
In ActiveRecord now it will actively try to typecast column types into Ruby Types.  
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/type.rb#L64-L75
I added a test that mocked the behavior some of us were seeing with ActiveRecord 6. The code will still allow for non Time class variables as well.

Fixes issue #314 