### PR TITLE
Add testing for ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,46 @@ jobs:
         path: test/reports/
     - store_test_results:
         path: test/reports/
+  test_ruby_2_7:
+    docker:
+    - image: circleci/ruby:2.7
+      environment:
+        RAILS_ENV: test
+        RACK_ENV: test
+        POSTGRES_USER: root
+        PGHOST: 127.0.0.1
+        DATABASE_URL: postgres://postgres@127.0.0.1/circle_test
+        QC_DATABASE_URL: postgres://postgres@127.0.0.1/circle_test
+        QC_BENCHMARK: true
+        QC_BENCHMARK_MAX_TIME_DEQUEUE: 60
+    - image: circleci/postgres:9.6.6-alpine
+    steps:
+    - checkout
+    - run:
+        name: Install env dependencies
+        command: |
+          sudo apt-get update
+          sudo apt-get install postgresql-client
+    - restore_cache:
+        key: v1-qc-bundler-{{ checksum "Gemfile" }}-{{ checksum "queue_classic.gemspec"
+          }}
+    - run:
+        name: Install Ruby gems
+        command: |
+          bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+    - save_cache:
+        key: v1-qc-bundler-{{ checksum "Gemfile" }}-{{ checksum "queue_classic.gemspec"
+          }}
+        paths:
+        - ~/project/vendor/bundle
+    - run:
+        name: Minitest
+        command: |
+          bundle exec rake
+    - store_artifacts:
+        path: test/reports/
+    - store_test_results:
+        path: test/reports/
 workflows:
   version: 2
   test:
@@ -148,4 +188,5 @@ workflows:
     - test_ruby_2_4
     - test_ruby_2_5
     - test_ruby_2_6
+    - test_ruby_2_7
     - test_fresh_install_rails_5_2_3

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A major benefit is the ability to enqueue inside transactions, ensuring things a
 ### Requirements
 
 For this version, the requirements are as follows:
-* Ruby 2.4, 2.5 or 2.6
+* Ruby 2.4, 2.5, 2.6 or 2.7
 * Postgres ~> 9.6
 * Rubygem: pg ~> 0.17
 


### PR DESCRIPTION
Thanks a lot for your work! I would like to mention support for Ruby 2.7.

Ruby 2.7 was released in [December 2019](https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/) a minor [release 2.7.1](https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-7-1-released/) has also been released.