### PR TITLE
App 3445 fix connection is closed errors in queue classic

### DIFF
--- a/lib/queue_classic/conn_adapter.rb
+++ b/lib/queue_classic/conn_adapter.rb
@@ -15,6 +15,10 @@ module QC
         QC.log(:at => "exec_sql", :sql => stmt.inspect)
         begin
           params = nil if params.empty?
+          if @connection.finished?
+            # this will only work if ActiveRecord is included
+            @connection = ActiveRecord::Base.connection.raw_connection
+          end
           r = @connection.exec(stmt, params)
           result = []
           r.each {|t| result << t}

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -112,6 +112,50 @@ class QueueTest < QCTest
     queue.conn_adapter.disconnect
   end
 
+  def test_enqueue_retry
+    queue = QC::Queue.new("queue_classic_jobs")
+    queue.conn_adapter = QC::ConnAdapter.new
+    conn = queue.conn_adapter.connection
+    conn.exec('select pg_terminate_backend(pg_backend_pid())') rescue nil
+    queue.enqueue("Klass.method")
+    assert_equal(1, queue.count)
+    queue.conn_adapter.disconnect
+  end
+
+  def test_enqueue_stops_retrying_on_permanent_error
+    queue = QC::Queue.new("queue_classic_jobs")
+    queue.conn_adapter = QC::ConnAdapter.new
+    conn = queue.conn_adapter.connection
+    conn.exec('select pg_terminate_backend(pg_backend_pid())') rescue nil
+    # Simulate permanent connection error
+    def conn.exec(*args); raise(PGError); end
+    # Ensure that the error is reraised on second time
+    assert_raises(PG::Error) {queue.enqueue("Klass.other_method")}
+    queue.conn_adapter.disconnect
+  end
+
+  def test_enqueue_in_retry
+    queue = QC::Queue.new("queue_classic_jobs")
+    queue.conn_adapter = QC::ConnAdapter.new
+    conn = queue.conn_adapter.connection
+    conn.exec('select pg_terminate_backend(pg_backend_pid())') rescue nil
+    queue.enqueue_in(10,"Klass.method")
+    assert_equal(1, queue.count)
+    queue.conn_adapter.disconnect
+  end
+
+  def test_enqueue_in_stops_retrying_on_permanent_error
+    queue = QC::Queue.new("queue_classic_jobs")
+    queue.conn_adapter = QC::ConnAdapter.new
+    conn = queue.conn_adapter.connection
+    conn.exec('select pg_terminate_backend(pg_backend_pid())') rescue nil
+    # Simulate permanent connection error
+    def conn.exec(*args); raise(PGError); end
+    # Ensure that the error is reraised on second time
+    assert_raises(PG::Error) {queue.enqueue_in(10,"Klass.method")}
+    queue.conn_adapter.disconnect
+  end
+
   def test_custom_default_queue
     queue_class = Class.new do
       attr_accessor :jobs


### PR DESCRIPTION
When queueing a job, always check if connection has been closed. If it is, acquire a new one from ActiveRecord pool