### PR TITLE
Add success_handler to give subclass control over success

### DIFF
--- a/lib/queue_classic/version.rb
+++ b/lib/queue_classic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QC
-  VERSION = "4.0.0-alpha1"
+  VERSION = "4.0.1-alpha1"
 end

--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -111,7 +111,7 @@ module QC
       finished = false
       begin
         call(job).tap do
-          handle_success(job)
+          handle_success(queue, job)
           finished = true
         end
       rescue StandardError, ScriptError, NoMemoryError => e
@@ -139,7 +139,7 @@ module QC
       receiver.send(message, *args)
     end
 
-    def handle_success(job)
+    def handle_success(queue, job)
       queue.delete(job[:id])
     end
 


### PR DESCRIPTION
Allows custom worker to override and instead of deleting the queue item, moving it a `successful_jobs` queue for auditing purposes. 