### PR TITLE
Use nil for tty option in normalize_db_url

### DIFF
--- a/lib/queue_classic/conn_adapter.rb
+++ b/lib/queue_classic/conn_adapter.rb
@@ -107,7 +107,7 @@ module QC
       [
        host, # host or percent-encoded socket path
        url.port || 5432,
-       nil, '', #opts, tty
+       nil, nil, #opts, tty
        url.path.gsub("/",""), # database name
        url.user,
        url.password


### PR DESCRIPTION
Per suggestion in #333

We noticed queue_classic has been failing ActiveJob's builds since the new postgresql release.

It feels like it might be better to just forward to URL to the pg gem, or to use a hash of options instead, but this PR should be the smallest fix to the issue.