### PR TITLE
Remove eval

### DIFF
--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -134,9 +134,16 @@ module QC
     # the object and pass the args.
     def call(job)
       args = job[:args]
-      receiver_str, _, message = job[:method].rpartition('.')
-      receiver = eval(receiver_str)
-      receiver.send(message, *args)
+      method_chain = job[:method].split('.')
+
+      # Start with the base receiver, which should be a constant 🤞
+      base_receiver_str = method_chain.shift
+      base_receiver = base_receiver_str.split('::').inject(Object) { |acc, val| acc.const_get(val) }
+
+      # run through the chain of methods 🚀
+      method_chain.reduce(base_receiver) do |receiver, method|
+        method == method_chain.last ? receiver.send(method, *args) : receiver.send(method)
+      end
     end
 
     def handle_success(queue, job)


### PR DESCRIPTION
This is a WIP to remove the use of eval, but it's currently broken on some edge cases.

Also, this risks breaking use cases which aren't just calling things with params.