### PR TITLE
Draft: Add option to disable LISTEN/NOTIFY in workers

### DIFF
--- a/lib/queue_classic/config.rb
+++ b/lib/queue_classic/config.rb
@@ -14,6 +14,13 @@ module QC
     def wait_time
       @wait_time ||= (ENV['QC_LISTEN_TIME'] || 5).to_i
     end
+    
+    # Whether workers should use PostgreSQL LISTEN/NOTIFY while waiting for jobs.
+    def listen_notify?
+      return @listen_notify unless @listen_notify.nil?
+
+      @listen_notify = ENV.fetch('QC_LISTEN_NOTIFY', 'true') != 'false'
+    end
 
     # Why do you want to change the table name?
     # Just deal with the default OK?
@@ -78,6 +85,7 @@ module QC
       # TODO: we might want to think about storing these in a Hash.
       @app_name = nil
       @wait_time = nil
+      @listen_notify = nil
       @table_name = nil
       @queue = nil
       @default_queue = nil

--- a/lib/queue_classic/conn_adapter.rb
+++ b/lib/queue_classic/conn_adapter.rb
@@ -38,6 +38,8 @@ module QC
     end
 
     def wait(time, *channels)
+      return Kernel.sleep(time) unless QC.listen_notify?
+
       @mutex.synchronize do
         listen_cmds = channels.map { |c| "LISTEN \"#{c}\"" }
         connection.exec(listen_cmds.join(';'))

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -31,6 +31,19 @@ class ConfigTest < QCTest
     end
   end
 
+  def test_listen_notify_default
+    assert QC.listen_notify?
+  end
+
+  def test_configure_listen_notify_with_env_var
+    with_env 'QC_LISTEN_NOTIFY' => 'false' do
+      QC.reset_config
+      refute QC.listen_notify?
+    end
+  end
+
+
+
   def test_table_name_default
     assert_equal 'queue_classic_jobs', QC.table_name
   end

--- a/test/conn_adapter_test.rb
+++ b/test/conn_adapter_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+class ConnAdapterTest < QCTest
+  class FakeConnection
+    attr_reader :statements, :wait_time
+
+    def initialize
+      @statements = []
+      @wait_time = nil
+    end
+
+    def exec(statement)
+      @statements << statement
+      []
+    end
+
+    def wait_for_notify(time)
+      @wait_time = time
+    end
+
+    def notifies
+      nil
+    end
+  end
+
+  def setup
+    QC.reset_config
+  end
+
+  def teardown
+    QC.reset_config
+  end
+
+  # This test ensures that the connection adapter 
+  # correctly uses LISTEN/NOTIFY when waiting for 
+  # jobs, and falls back to sleeping when 
+  # LISTEN/NOTIFY is disabled.
+  def test_wait_uses_listen_notify_by_default
+    connection = FakeConnection.new
+    adapter = QC::ConnAdapter.new(connection: connection)
+
+    adapter.wait(0, 'default')
+
+    assert_includes connection.statements, 'LISTEN "default"'
+    assert_includes connection.statements, 'UNLISTEN "default"'
+    assert_equal 0, connection.wait_time
+  end
+
+  # This test ensures that the connection 
+  # adapter falls back to polling when 
+  # LISTEN/NOTIFY is disabled.
+  def test_wait_uses_polling_sleep_when_listen_notify_is_disabled
+    connection = FakeConnection.new
+    adapter = QC::ConnAdapter.new(connection: connection)
+
+    with_env 'QC_LISTEN_NOTIFY' => 'false' do
+      QC.reset_config
+      adapter.wait(0, 'default')
+    end
+
+    assert_empty connection.statements
+    assert_nil connection.wait_time
+  end
+end
+
+
+


### PR DESCRIPTION
This is a draft implementation for the behavior discussed in #355.

The goal is to support polling-only workers for deployments using PgBouncer transaction pooling.

I am opening this as a draft to get feedback on the configuration interface before finalizing tests and documentation.